### PR TITLE
Updating the ROS2 image to work with alpha7

### DIFF
--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -31,7 +31,7 @@ RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/ap
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
-RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable @os_code_name main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 # ROS2 Setup ###################################################################
 @[if 'packages' in locals()]@


### PR DESCRIPTION
The xenial docker image is very minimal, and doesn't ship with lsb_release.

This is needed for https://github.com/osrf/docker_images/pull/37