### PR TITLE
Revert "Removed deb packages from the APT cache"

### DIFF
--- a/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -27,8 +27,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@ \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@

--- a/ros_docker_images/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -20,13 +20,11 @@
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@ \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -17,8 +17,7 @@
 
 RUN apt-get update && apt-get install -y \
     software-properties-common  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 RUN apt-add-repository ppa:libccd-debs \
     && apt-add-repository ppa:fcl-debs \
@@ -43,8 +42,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep
 RUN rosdep init \
@@ -53,8 +51,7 @@ RUN rosdep init \
 # install ros packages
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 @[end if]@
 @[end if]@
 
@@ -70,8 +67,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 @[end if]@
 @[end if]@
 
@@ -80,8 +76,7 @@ RUN apt-get update && apt-get install -q -y \
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 @[end if]@
 @[end if]@
 

--- a/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -20,8 +20,7 @@
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@ \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@
@@ -35,8 +34,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_releas
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # setup environment
 EXPOSE 11345

--- a/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -20,16 +20,14 @@
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@ \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # clone gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb

--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -39,8 +39,7 @@ RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable @os_code_na
 # install packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 @[end if]@
 @[end if]@
 

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -24,8 +24,7 @@ ENV LANG en_US.UTF-8
 # install packages
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@
@@ -41,8 +40,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # bootstrap rosdep
 RUN rosdep init \
@@ -52,8 +50,7 @@ RUN rosdep init \
 ENV ROS_DISTRO @rosdistro_name
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

--- a/ros_docker_images/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_image.Dockerfile.em
@@ -20,8 +20,7 @@
 # install packages
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@
@@ -31,8 +30,7 @@ RUN apt-get update && apt-get install -y \
 # install ros packages
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 @[end if]@
 @[end if]@


### PR DESCRIPTION
Reverts osrf/docker_templates#9

This is not really necessary since the base Docker images already clean up the APT cache after fetching the packages.