### PR TITLE
Install locales before RUN locale-gen for ROS2 image

### DIFF
--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -17,6 +17,9 @@
 
 # ROS1 Repo Setup ##############################################################
 # setup environment
+RUN apt-get update && apt-get install -q -y \
+    locales \
+     && rm -rf /var/lib/apt/lists/*
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 


### PR DESCRIPTION
The Docker has failed to build osrf/ros2 image since 6 months ago. See the AUTOMATED BUILD status below.

https://hub.docker.com/r/osrf/ros2/builds/brxsuwjm7esphiksytjagzm/

~~~
Step 3/19 : RUN locale-gen en_US.UTF-8

 ---> Running in e3b4dae7e237

[91m/bin/sh: 1: locale-gen: not found
[0m
Removing intermediate container e3b4dae7e237

The command '/bin/sh -c locale-gen en_US.UTF-8' returned a non-zero code: 127
~~~

It causes current ubuntu:xenial image no longer install **locales** by default. This PR installs it before call **locale-gen**.