### PR TITLE
install locales before calling locale-gen

### DIFF
--- a/ros_docker_images/templates/docker_images/create_base_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_base_image.Dockerfile.em
@@ -9,7 +9,10 @@
     maintainer_name=maintainer_name,
 ))@
 
-RUN locale-gen en_US.UTF-8
+# setup environment
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV TZ @timezone
 

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -27,7 +27,9 @@ RUN apt-add-repository ppa:libccd-debs \
 @[if ros_packages]@
 # ROS Setup ####################################################################
 # setup environment
-RUN locale-gen en_US.UTF-8
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # setup keys

--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -40,7 +40,9 @@ RUN apt-get update && apt-get install -q -y \
 @[end if]@
 @[end if]@
 # setup environment
-RUN locale-gen en_US.UTF-8
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -16,7 +16,9 @@
 ))@
 
 # setup environment
-RUN locale-gen en_US.UTF-8
+RUN apt-get update && apt-get install -y \
+    locales \
+    && locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 @[if 'packages' in locals()]@
 @[if packages]@


### PR DESCRIPTION
ubuntu doesn't ship `locales` in its image anymore. We need to install it ourselves otherwise the docker images cannot be built. (see https://github.com/ros-infrastructure/ros_buildfarm/pull/415)