### PR TITLE
Install locales round2

### DIFF
--- a/ros_docker_images/templates/docker_images/create_base_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_base_image.Dockerfile.em
@@ -19,14 +19,12 @@
 
 # install bootstrap tools
 RUN apt-get update && apt-get install -q -y \
-    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools
 
 # setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
+ENV LANG C.UTF-8
 ENV TZ @timezone
 
 # bootstrap rosdep

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -35,17 +35,14 @@ RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/ap
 # install bootstrap tools
 ENV ROS_DISTRO @rosdistro_name
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -44,6 +44,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # setup environment
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
 
 @[end if]@
 @[end if]@
-
 # setup keys
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
@@ -43,6 +42,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # setup environment
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
+
 # bootstrap rosdep
 RUN rosdep init \
     && rosdep update

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -33,17 +33,14 @@ RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/ap
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    locales \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -42,6 +42,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # setup environment
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # bootstrap rosdep
 RUN rosdep init \


### PR DESCRIPTION
Looks like ubuntu ships with C.UTF-8, is it pertinent that our official images include en_US.UTF-8?
https://botbot.me/freenode/docker-library/2017-05-23/?msg=86040387&page=1

The whole stack of dockerfiles for lunar builds fine with this template, but this may be more of a runtime requirement. Any real reason that necessitates en_US.UTF-8 ? I thought this just needed to be set to something that supports unicode. 

https://community.hpe.com/t5/General/Difference-between-C-utf8-and-en-us-utf8-points/td-p/4418194