### PR TITLE
Removing lsb-release package requirement

### DIFF
--- a/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -30,7 +30,8 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB
 
 # setup sources.list
 RUN . /etc/os-release \
-    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable $VERSION_CODENAME main" > /etc/apt/sources.list.d/gazebo-latest.list
+    && . /etc/lsb-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable $DISTRIB_CODENAME main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \

--- a/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -q -y \
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
-RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
+RUN . /etc/os-release \
+    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable $VERSION_CODENAME main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \

--- a/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -35,7 +35,7 @@ RUN hg clone https://bitbucket.org/osrf/gzweb ~/gzweb
 # build gzweb
 RUN cd ~/gzweb \
     && hg up default \
-    && ./deploy.sh -m
+    && xvfb-run -s "-screen 0 1280x1024x24" ./deploy.sh -m
 
 # setup environment
 EXPOSE 8080


### PR DESCRIPTION
Having the template look into the etc files for distro version info instead of the lsb-release command.
https://www.freedesktop.org/software/systemd/man/os-release.html
However ubuntu 14.04 doesn't have all the modern verabels set, thus the need for sourcing both /etc/lsb-release and /etc/os-release.