### PR TITLE
Omitting timestamp

### DIFF
--- a/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',

--- a/ros_docker_images/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_image.Dockerfile.em
@@ -3,7 +3,6 @@
     user_name=user_name,
     tag_name=tag_name,
     source_template_name=template_name,
-    now_str=now_str,
 ))@
 @(TEMPLATE(
     'snippet/from_base_image.Dockerfile.em',


### PR DESCRIPTION
To enable auto Dockerfile diff checking for things like version bumps
having changed the template primitive accordingly https://github.com/ruffsl/ros_buildfarm/commit/e850eba6b88e54a9b60e2063031b31da9a69ab92