### PR TITLE
Updating keyserver URL to p80 pool

### DIFF
--- a/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -15,7 +15,7 @@
 ))@
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -26,7 +26,7 @@ RUN apt-add-repository ppa:libccd-debs \
 @[if ros_packages]@
 # ROS Setup ####################################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install -y \
 @[if gazebo_packages]@
 # Gazebo Setup #################################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -q -y \
 @[end if]@
 
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN . /etc/os-release \

--- a/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -16,14 +16,14 @@
 
 # ROS1 Repo Setup ##############################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
 
 # OSRF Repo Setup ##############################################################
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
 
 # setup sources.list
 RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable @os_code_name main" > /etc/apt/sources.list.d/gazebo-latest.list

--- a/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/ros_docker_images/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y \
 @[end if]@
 @[end if]@
 # setup keys
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/@os_name @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list


### PR DESCRIPTION
to better support building dockerfiles behind firewalls.
Also leaving no old examples behind to avoid others from copying old style from templates
See https://github.com/osrf/docker_images/pull/62 for context