### PR TITLE
Reverting lang setup to stop printed warnings

### DIFF
--- a/docker_templates/templates/docker_images/create_ros_eol_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_eol_image.Dockerfile.em
@@ -35,8 +35,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 RUN echo "deb http://packages.ros.org/ros/ubuntu @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
 
 # setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 # install ros packages
 ENV ROS_DISTRO @rosdistro_name


### PR DESCRIPTION
old ubuntu images seem to still have locale-gen still pre-installed.