### PR TITLE
remove ubuntu specific variables and use template variables instead

### DIFF
--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -23,15 +23,13 @@
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://packages.ros.org/ros/ubuntu $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
 
 # setup ros2 keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://repo.ros2.org/$ID/main $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://repo.ros2.org/@os_name/main @os_code_name main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -23,8 +23,7 @@
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://repo.ros2.org/$ID/main $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://repo.ros2.org/@os_name/main @os_code_name main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8


### PR DESCRIPTION
As ROS2 may target non ubuntu distributions in the future, we should make the templates distribution agnostic.
As we already have all the information provided as template arguments I didnt go the route of installing lsb-release and checking the value it returns.