### PR TITLE
Experiment upstream packages

### DIFF
--- a/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -19,7 +19,7 @@
     os_code_name=os_code_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release'
@@ -27,7 +27,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -24,22 +24,12 @@ packages = [
     'gnupg2',
     'lsb-release'
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@ \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /var/lib/apt/lists/partial
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -13,16 +13,24 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@[if 'packages' in locals()]@
-@[  if packages]@
+@{
+packages = []
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 
 # install packages
 RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@ \
+    @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
-@[  end if]@
 @[end if]@
+@
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \

--- a/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -13,23 +13,11 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@{
-packages = []
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
-}@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=[],
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \

--- a/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -26,21 +26,12 @@ packages = [
     'lsb-release'
     'software-properties-common'
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 RUN apt-add-repository ppa:libccd-debs \
     && apt-add-repository ppa:fcl-debs \

--- a/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -20,7 +20,7 @@
     os_code_name=os_code_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release'
@@ -29,7 +29,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -19,7 +19,7 @@
     os_code_name=os_code_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release',
@@ -27,7 +27,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -13,7 +13,6 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-
 @(TEMPLATE(
     'snippet/setup_tzdata.Dockerfile.em',
     os_name=os_name,
@@ -23,22 +22,14 @@
 packages = [
     'dirmngr',
     'gnupg2',
-    'lsb-release'
+    'lsb-release',
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743

--- a/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -14,13 +14,13 @@
     maintainer_name=maintainer_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'mercurial',
 ]
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -13,16 +13,26 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@[if 'packages' in locals()]@
-@[  if packages]@
+@{
+packages = [
+    'mercurial',
+]
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 
 # install packages
 RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@ \
+    @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
-@[  end if]@
 @[end if]@
+@
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \
     @(' \\\n    '.join(gazebo_packages))@  \

--- a/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -17,21 +17,12 @@
 packages = [
     'mercurial',
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # install gazebo packages
 RUN apt-get update && apt-get install -q -y \

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -19,7 +19,7 @@
     os_code_name=os_code_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release'
@@ -27,7 +27,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -23,15 +23,13 @@
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://packages.ros.org/ros/ubuntu $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
 
 # setup ros2 keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://repo.ros2.org/$ID/main $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://repo.ros2.org/@os_name/main @os_code_name main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -24,21 +24,12 @@ packages = [
     'gnupg2',
     'lsb-release'
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # setup ros1 keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116

--- a/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -13,23 +13,11 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-
-@{
-packages = []
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
-}@
-@
-@[if packages != []]@
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=[],
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@

--- a/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -14,15 +14,23 @@
     maintainer_name=maintainer_name,
 ))@
 
-@[if 'packages' in locals()]@
-@[  if packages]@
+@{
+packages = []
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
-@[  end if]@
 @[end if]@
+@
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@
 # install python packages

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -18,12 +18,34 @@
     os_name=os_name,
     os_code_name=os_code_name,
 ))@
+@{
+packages = [
+    'dirmngr',
+    'gnupg2',
+    'lsb-release'
+]
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 
+# install packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    @(' \\\n    '.join(packages))@  \
+    && rm -rf /var/lib/apt/lists/*
+
+@[end if]@
+@
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN echo "deb http://repo.ros2.org/@os_name/main @os_code_name main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN . /etc/os-release \
+    && echo "deb http://repo.ros2.org/$ID/main `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8
@@ -32,12 +54,13 @@ ENV LC_ALL C.UTF-8
 @[if 'packages' in locals()]@
 @[  if packages]@
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
 @[  end if]@
 @[end if]@
+@
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@
 # install python packages
@@ -46,9 +69,10 @@ RUN pip3 install -U \
 
 @[  end if]@
 @[end if]@
-
+@
 @[if 'vcs' in locals()]@
 @[  if vcs]@
+
 # clone source
 ENV ROS2_WS @(ws)
 RUN mkdir -p $ROS2_WS/src

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -42,11 +42,11 @@ RUN . /etc/os-release \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-@[if 'packages' in locals()]@
-@[  if packages]@
-# install packages
+@[if 'ros_hosted_packages' in locals()]@
+@[  if ros_hosted_packages]@
+# install packages from the ROS repositories
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
+    @(' \\\n    '.join(ros_hosted_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
 @[  end if]@

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -42,11 +42,11 @@ RUN . /etc/os-release \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-@[if 'packages' in locals()]@
-@[  if packages]@
+@[if 'ros2_repo_packages' in locals()]@
+@[  if ros2_repo_packages]@
 # install packages from the ROS repositories
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
+    @(' \\\n    '.join(ros2_repo_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
 @[  end if]@

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -24,21 +24,12 @@ packages = [
     'gnupg2',
     'lsb-release'
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -19,7 +19,7 @@
     os_code_name=os_code_name,
 ))@
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release'
@@ -27,7 +27,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @
@@ -42,11 +42,11 @@ RUN . /etc/os-release \
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-@[if 'ros_hosted_packages' in locals()]@
-@[  if ros_hosted_packages]@
+@[if 'packages' in locals()]@
+@[  if packages]@
 # install packages from the ROS repositories
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros_hosted_packages))@  \
+    @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
 @[  end if]@

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -23,8 +23,7 @@
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN . /etc/os-release \
-    && echo "deb http://repo.ros2.org/$ID/main $VERSION_CODENAME main" > /etc/apt/sources.list.d/ros2-latest.list
+RUN echo "deb http://repo.ros2.org/@os_name/main @os_code_name main" > /etc/apt/sources.list.d/ros2-latest.list
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -21,7 +21,7 @@
 ))@
 @
 @{
-packages = [
+template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release',
@@ -29,7 +29,7 @@ packages = [
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=packages,
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -26,21 +26,12 @@ packages = [
     'gnupg2',
     'lsb-release',
 ]
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
 }@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=packages,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -19,21 +19,34 @@
     os_name=os_name,
     os_code_name=os_code_name,
 ))@
-@[if 'packages' in locals()]@
-@[  if packages]@
+@
+@{
+packages = [
+    'dirmngr',
+    'gnupg2',
+    'lsb-release',
+]
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 
 # install packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
-@[  end if]@
 @[end if]@
+@
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
 # install bootstrap tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -13,16 +13,25 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@[if 'packages' in locals()]@
-@[  if packages]@
+@{
+packages = []
+if 'upstream_packages' in locals():
+    if isinstance(upstream_packages, list):
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+}@
+@
+@[if packages != []]@
 
 # install packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/lib/apt/lists/partial
 
-@[  end if]@
 @[end if]@
+@
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
 

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -13,24 +13,11 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@{
-packages = []
-if 'upstream_packages' in locals():
-    if isinstance(upstream_packages, list):
-        for pkg in upstream_packages:
-            if pkg not in packages:
-                packages.append(pkg)
-}@
-@
-@[if packages != []]@
-
-# install packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(packages))@  \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /var/lib/apt/lists/partial
-
-@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=[],
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
 @
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@

--- a/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
@@ -1,10 +1,11 @@
 @{
 if isinstance(packages, list):
     if isinstance(upstream_packages, list):
-        # for pkg in upstream_packages:
-        #     if pkg not in packages:
-        #         packages.append(pkg)
-        packages.extend([pkg for pkg in upstream_packages if pkg not in packages])
+        for pkg in upstream_packages:
+            if pkg not in packages:
+                packages.append(pkg)
+        # This doesnt work in empy
+        # packages.extend([pkg for pkg in upstream_packages if pkg not in packages])
 }@
 @[if isinstance(packages, list)]@
 @[  if packages != []]@

--- a/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
@@ -4,8 +4,6 @@ if isinstance(packages, list):
         for pkg in upstream_packages:
             if pkg not in packages:
                 packages.append(pkg)
-        # This doesnt work in empy
-        # packages.extend([pkg for pkg in upstream_packages if pkg not in packages])
 }@
 @[if isinstance(packages, list)]@
 @[  if packages != []]@

--- a/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
@@ -1,0 +1,18 @@
+@{
+if isinstance(packages, list):
+    if isinstance(upstream_packages, list):
+        # for pkg in upstream_packages:
+        #     if pkg not in packages:
+        #         packages.append(pkg)
+        packages.extend([pkg for pkg in upstream_packages if pkg not in packages])
+}@
+@[if isinstance(packages, list)]@
+@[  if packages != []]@
+
+# install packages
+RUN apt-get update && apt-get install -q -y \
+    @(' \\\n    '.join(sorted(packages)))@  \
+    && rm -rf /var/lib/apt/lists/*
+
+@[  end if]@
+@[end if]@


### PR DESCRIPTION
alternative to #36 

This uses the common denominator in behavior of `os-release` and `lsb-release` on Debian and Ubuntu to not hard-code either the OS name or the OS code name in the containers.

This also implements the suggestion from https://github.com/osrf/docker_templates/pull/36#issuecomment-389660082 to specify the packages needed by the template in the template itself and to allow users to extend the list without adding layers.
To make it explicit that these packages have to be available pstream and not in custom apt repos (ros, osrfoundation etc) I renamed the key to be upstream_packages.

A few notes:
- A change to the docker_images images template will be needed as well to match the new keys
- I didnt modify the legacy ros images accorgingly for now as I dont expect them to be reuseable
- the package list extension logic is pretty verbose. For some reason I couldnt get EmPy to use varialbes from the same scope in list comprehension..