### PR TITLE
install pip3 only if requested

### DIFF
--- a/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -22,7 +22,7 @@
 template_dependencies = [
     'dirmngr',
     'gnupg2',
-    'lsb-release'
+    'lsb-release',
 ]
 }@
 @(TEMPLATE(

--- a/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -23,8 +23,8 @@
 template_dependencies = [
     'dirmngr',
     'gnupg2',
-    'lsb-release'
-    'software-properties-common'
+    'lsb-release',
+    'software-properties-common',
 ]
 }@
 @(TEMPLATE(

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -23,8 +23,10 @@ template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release',
-    'python3-pip',
 ]
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -22,7 +22,8 @@
 template_dependencies = [
     'dirmngr',
     'gnupg2',
-    'lsb-release'
+    'lsb-release',
+    'python3-pip',
 ]
 }@
 @(TEMPLATE(

--- a/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -13,9 +13,15 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
+@{
+template_dependencies = []
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
+}@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
-    packages=[],
+    packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -23,8 +23,10 @@ template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release',
-    'python3_pip,
 ]
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
 }@
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',

--- a/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_source_image.Dockerfile.em
@@ -22,7 +22,8 @@
 template_dependencies = [
     'dirmngr',
     'gnupg2',
-    'lsb-release'
+    'lsb-release',
+    'python3_pip,
 ]
 }@
 @(TEMPLATE(


### PR DESCRIPTION
This is a follow up of #37 
This adds missing commas to reduce future diffs, and installs python3-pip only if users request pip packages to be installed via the `pip3_install` variable
