### PR TITLE
Homogenize ROS_DISTRO

### DIFF
--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -35,11 +35,6 @@ if 'pip3_install' in locals():
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @
-# setup ros1 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
-
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
 # setup ros2 keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
@@ -67,15 +62,6 @@ RUN pip3 install -U \
 @[  end if]@
 @[end if]@
 
-@[if 'ros_packages' in locals()]@
-@[  if ros_packages]@
-# install ros packages
-RUN apt-get update && apt-get install -y \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[  end if]@
-@[end if]@
 @[if 'ros2_packages' in locals()]@
 @[  if ros2_packages]@
 # install ros2 packages

--- a/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_core_image.Dockerfile.em
@@ -46,12 +46,8 @@ RUN . /etc/os-release \
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
-@[if 'rosdistro_name' in locals()]@
-@[  if rosdistro_name]@
-ENV ROS_DISTRO @rosdistro_name
-@[  end if]@
-@[end if]@
-ENV ROS2_DISTRO @ros2distro_name
+
+ENV ROS_DISTRO @ros2distro_name
 
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@

--- a/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -34,23 +34,6 @@ RUN pip3 install -U \
 
 @[  end if]@
 @[end if]@
-@[if 'ros_packages' in locals()]@
-@[  if ros_packages]@
-
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
-
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
-
-# install ros packages
-RUN apt-get update && apt-get install -y \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV ROS1_DISTRO @rosdistro_name
-@[  end if]@
-@[end if]@
 @[if 'ros2_packages' in locals()]@
 @[  if ros2_packages]@
 # install ros2 packages

--- a/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_image.Dockerfile.em
@@ -36,11 +36,19 @@ RUN pip3 install -U \
 @[end if]@
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+
 # install ros packages
 RUN apt-get update && apt-get install -y \
     @(' \\\n    '.join(ros_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
+ENV ROS1_DISTRO @rosdistro_name
 @[  end if]@
 @[end if]@
 @[if 'ros2_packages' in locals()]@

--- a/docker_templates/templates/docker_images/create_ros2_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_ros1_bridge_image.Dockerfile.em
@@ -1,0 +1,79 @@
+@(TEMPLATE(
+    'snippet/add_generated_comment.Dockerfile.em',
+    user_name=user_name,
+    tag_name=tag_name,
+    source_template_name=template_name,
+))@
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    template_packages=template_packages,
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+    base_image=base_image,
+    maintainer_name=maintainer_name,
+))@
+@{
+template_dependencies = []
+# add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
+}@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=template_dependencies,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
+@
+@[if 'pip3_install' in locals()]@
+@[  if pip3_install]@
+# install python packages
+RUN pip3 install -U \
+    @(' \\\n    '.join(pip3_install))@
+
+@[  end if]@
+@[end if]@
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
+
+ENV ROS1_DISTRO @rosdistro_name
+@[if 'ros_packages' in locals()]@
+@[  if ros_packages]@
+# install ros packages
+RUN apt-get update && apt-get install -y \
+    @(' \\\n    '.join(ros_packages))@  \
+    && rm -rf /var/lib/apt/lists/*
+
+@[  end if]@
+@[end if]@
+@[if 'ros2_packages' in locals()]@
+@[  if ros2_packages]@
+# install ros2 packages
+RUN apt-get update && apt-get install -y \
+    @(' \\\n    '.join(ros2_packages))@  \
+    && rm -rf /var/lib/apt/lists/*
+
+@[  end if]@
+@[end if]@
+@[if 'entrypoint_name' in locals()]@
+@[  if entrypoint_name]@
+@{
+entrypoint_file = entrypoint_name.split('/')[-1]
+}@
+# setup entrypoint
+COPY ./@entrypoint_file /
+
+ENTRYPOINT ["/@entrypoint_file"]
+@{
+cmds = [
+'bash',
+]
+}@
+CMD ["@(' && '.join(cmds))"]
+@[  end if]@
+@[end if]@

--- a/docker_templates/templates/docker_images/create_ros2_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros2_ros1_bridge_image.Dockerfile.em
@@ -42,6 +42,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
 ENV ROS1_DISTRO @rosdistro_name
+ENV ROS2_DISTRO @ros2distro_name
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
 # install ros packages

--- a/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
+++ b/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
@@ -2,8 +2,8 @@
 set -e
 
 # setup ros1 environment
-source "/opt/ros/$ROS_DISTRO/setup.bash"
+source "/opt/ros/$ROS1_DISTRO/setup.bash"
 
 # setup ros2 environment
-source "/opt/ros/$ROS2_DISTRO/setup.bash"
+source "/opt/ros/$ROS_DISTRO/setup.bash"
 exec "$@"

--- a/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
+++ b/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 set -e
 
+unset ROS_DISTRO
 # setup ros1 environment
 source "/opt/ros/$ROS1_DISTRO/setup.bash"
 
 # setup ros2 environment
 source "/opt/ros/$ROS2_DISTRO/setup.bash"
+
+unset ROS1_DISTRO
+unset ROS2_DISTRO
 
 exec "$@"

--- a/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
+++ b/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 set -e
 
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
 unset ROS_DISTRO
 # setup ros1 environment
 source "/opt/ros/$ROS1_DISTRO/setup.bash"
 
+# unsetting ROS_DISTRO to silence ROS_DISTRO override warning
+unset ROS_DISTRO
 # setup ros2 environment
 source "/opt/ros/$ROS2_DISTRO/setup.bash"
 

--- a/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
+++ b/docker_templates/templates/docker_images/ros1_bridge_entrypoint.sh
@@ -5,5 +5,6 @@ set -e
 source "/opt/ros/$ROS1_DISTRO/setup.bash"
 
 # setup ros2 environment
-source "/opt/ros/$ROS_DISTRO/setup.bash"
+source "/opt/ros/$ROS2_DISTRO/setup.bash"
+
 exec "$@"

--- a/docker_templates/templates/docker_images/ros2_entrypoint.sh
+++ b/docker_templates/templates/docker_images/ros2_entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # setup ros2 environment
-source "/opt/ros/$ROS2_DISTRO/setup.bash"
+source "/opt/ros/$ROS_DISTRO/setup.bash"
 exec "$@"


### PR DESCRIPTION
The goal of this PR is to:
- Not have conflicting declaration of `ROS_DISTRO` between ROS 1 and ROS 2 images (`ROS_DISTRO` should always reflect the distribution of ROS the image is based on)
- Not rely on ROS1 repository for any "pure ROS 2" images

To do so this PR:
- create a new template for the ros1-bridge image, the only one supposed to mix ros distributions
- renames ROS2_DISTRO to ROS_DISTRO in all iimages
- create a ROS1_DISTRO env var only in the ros1-bridge images
- remove the ROS 1 apt repository from the "pure ROS 2" images

Related to https://github.com/osrf/docker_images/issues/187

Before being ready for review:
Needs some testing and the corresponding PR on `docker_images` to adapt the `images.yaml.em` template to use the new template for the bridge image