### PR TITLE
Always init rosdep if it is installed

### DIFF
--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -76,8 +76,8 @@ RUN pip3 install -U \
 @[  if vcs]@
 
 @[if 'rosdep' in locals()]@
-@[  if 'rosdistro_index_url' in rosdep]@
 # bootstrap rosdep
+@[  if 'rosdistro_index_url' in rosdep]@
 ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 @[  end if]@
 RUN rosdep init \

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -79,9 +79,9 @@ RUN pip3 install -U \
 @[  if 'rosdistro_index_url' in rosdep]@
 # bootstrap rosdep
 ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
+@[  end if]@
 RUN rosdep init \
     && rosdep update
-@[  end if]@
 @[end if]@
 
 # clone source


### PR DESCRIPTION
If rosdep is to be installed but `rosdistro_index_url` is unset, then avoid setting the environment variable but still initialize rosdep