### PR TITLE
pull rosdep out of vcs scope

### DIFF
--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -72,10 +72,8 @@ RUN pip3 install -U \
 @[  end if]@
 @[end if]@
 @
-@[if 'vcs' in locals()]@
-@[  if vcs]@
-
 @[if 'rosdep' in locals()]@
+
 # bootstrap rosdep
 @[  if 'rosdistro_index_url' in rosdep]@
 ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
@@ -83,6 +81,8 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 @[end if]@
+@[if 'vcs' in locals()]@
+@[  if vcs]@
 
 # clone source
 ENV ROS2_WS @(ws)

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -81,13 +81,13 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 @[end if]@
-@[if 'vcs' in locals()]@
-@[  if vcs]@
 
 # clone source
 ENV ROS2_WS @(ws)
 RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
+@[if 'vcs' in locals()]@
+@[  if vcs]@
 @(TEMPLATE(
     'snippet/vcs_import.Dockerfile.em',
     vcs=vcs,


### PR DESCRIPTION
As the initialization of rosdep should not be impacted by skip in the absence of `vcs` in the template parameters

The generated ros2 source Dockerfile will be identical as we specify both rosdep and vcs for that image