### PR TITLE
use template for ROS bootstrap tools installation

### DIFF
--- a/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
@@ -23,11 +23,10 @@
     os_code_name=os_code_name,
 ))@
 @
-# install bootstrap tools
-RUN apt-get update && apt-get install -q -y \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version='1',
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -46,13 +46,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
-# install bootstrap tools
 ENV ROS_DISTRO @rosdistro_name
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version='1',
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -41,7 +41,7 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=version,
+    ros_version=ros_version,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -41,7 +41,7 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version='1',
+    ros_version=version,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -39,12 +39,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python-rosdep \
-    python-rosinstall \
-    python-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version='1',
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -43,7 +43,7 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=version,
+    ros_version=ros_version,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -41,12 +41,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
 
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3-rosdep \
-    python3-rosinstall \
-    python3-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version='2',
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -43,7 +43,7 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version='2',
+    ros_version=version,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -47,7 +47,7 @@ ENV LC_ALL C.UTF-8
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version='2',
+    ros_version=version,
 ))@
 
 @[if 'ros2_repo_packages' in locals()]@

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -47,7 +47,7 @@ ENV LC_ALL C.UTF-8
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=version,
+    ros_version=ros_version,
 ))@
 
 @[if 'ros2_repo_packages' in locals()]@

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -45,14 +45,11 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-@{
-# add colcon packages to 'ros2_repo_packages' if colcon is used
-if 'colcon_args' in locals():
-    colcon_packages = [
-        'python3-colcon-common-extensions',
-    ]
-    ros2_repo_packages.extend(colcon_packages)
-}@
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version='2',
+))@
+
 @[if 'ros2_repo_packages' in locals()]@
 @[  if ros2_repo_packages]@
 # install packages from the ROS repositories

--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -1,0 +1,18 @@
+@{
+if ros_version == '2':
+    package_list = [
+        'python3-colcon-common-extensions',
+        'python3-rosdep',
+        'python3-vcstool',
+    ]
+else:
+    package_list = [
+        'python-rosdep',
+        'python-rosinstall',
+        'python-vcstools',
+    ]
+}@
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    @(' \\\n    '.join(sorted(package_list)))@  \
+    && rm -rf /var/lib/apt/lists/*

--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -1,6 +1,7 @@
 @{
-if ros_version == '2':
+if int(ros_version) == 2:
     package_list = [
+        'git',
         'python3-colcon-common-extensions',
         'python3-rosdep',
         'python3-vcstool',


### PR DESCRIPTION
This allow install only the bootstrap tools relevant for the distro (e.g. not installing rosinstall and vcstools in ROS 1).
Adding rosdep and colcon here also allows to not have to specify it in the config of each image using it (e.g. https://github.com/osrf/docker_images/blob/086440f267921cf4ff39e90bb8e07c81e243dddc/ros2/source/images.yaml.em#L20)