### PR TITLE
Ros2 devel

### DIFF
--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -107,7 +107,6 @@ WORKDIR $ROS2_WS
 @[if 'colcon_args' in locals()]@
 @[  if colcon_args]@
 # build source
-WORKDIR $ROS2_WS
 RUN colcon \
     @(' \\\n    '.join(colcon_args))@
 

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -70,6 +70,7 @@ RUN pip3 install -U \
 @[end if]@
 
 ENV ROS_DISTRO @ros2_distro
+
 # bootstrap rosdep
 @[if 'rosdep' in locals()]@
 @[  if 'rosdistro_index_url' in rosdep]@

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -79,8 +79,6 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 @[end if]@
-@[if 'vcs' in locals()]@
-@[  if vcs]@
 
 # clone source
 ENV ROS2_WS @(ws)

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -68,17 +68,16 @@ RUN pip3 install -U \
 
 @[  end if]@
 @[end if]@
-@
-@[if 'rosdep' in locals()]@
 
-# bootstrap rosdep
 ENV ROS_DISTRO @ros2_distro
+# bootstrap rosdep
+@[if 'rosdep' in locals()]@
 @[  if 'rosdistro_index_url' in rosdep]@
 ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 @[  end if]@
+@[end if]@
 RUN rosdep init \
     && rosdep update
-@[end if]@
 
 # clone source
 ENV ROS2_WS @(ws)
@@ -86,6 +85,7 @@ RUN mkdir -p $ROS2_WS/src
 WORKDIR $ROS2_WS
 @[if 'vcs' in locals()]@
 @[  if vcs]@
+
 @(TEMPLATE(
     'snippet/vcs_import.Dockerfile.em',
     vcs=vcs,

--- a/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/source/create_ros_image.Dockerfile.em
@@ -79,6 +79,8 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 @[end if]@
+@[if 'vcs' in locals()]@
+@[  if vcs]@
 
 # clone source
 ENV ROS2_WS @(ws)

--- a/docker_templates/templates/docker_images_ros2/source/ros_entrypoint.sh
+++ b/docker_templates/templates/docker_images_ros2/source/ros_entrypoint.sh
@@ -2,5 +2,5 @@
 set -e
 
 # setup ros2 environment
-source "$ROS2_WS/install/local_setup.bash"
+source "$ROS2_WS/install/setup.bash"
 exec "$@"


### PR DESCRIPTION
Changes to source template to be used for ros2:source and ros2:devel image

Builds on top of https://github.com/osrf/docker_templates/pull/52

Changes:
- always initialize rosdep https://github.com/osrf/docker_templates/commit/74bc05c5e4ec332faa4c888d9b777fcf6ed0e4e7
- deduplicate WORKDIR https://github.com/osrf/docker_templates/commit/b1946721b4c611970b55807c1279921e7b3b6f88
- homogenize entrypoint to be the same as official images: https://github.com/osrf/docker_templates/commit/e82733f1aecbcd98e71e6d40defe99385f62a31e