### PR TITLE
Ros2 nightly rebased

### DIFF
--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -67,7 +67,7 @@ RUN pip3 install -U \
 # install ros2 packages
 ENV ROS_DISTRO @ros2distro_name
 RUN mkdir -p /opt/ros/$ROS_DISTRO
-ENV ROS2_BINARY_URL @ros2_binary_url
+ARG ROS2_BINARY_URL=@ros2_binary_url
 RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
 

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -23,6 +23,7 @@ template_dependencies = [
     'dirmngr',
     'gnupg2',
     'lsb-release',
+    'wget',
 ]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
 if 'pip3_install' in locals():

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -44,7 +44,7 @@ RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=version,
+    ros_version=ros_version,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -98,6 +98,10 @@ RUN apt-get update && apt install -q -y \
     ros-$ROS_DISTRO-ros-workspace \
     && rm -rf /var/lib/apt/lists/*
 
+# FIXME Remove this once rosdep detects ROS 2 packages https://github.com/ros-infrastructure/rosdep/issues/660
+# ignore installed rosdep keys
+ENV ROS_PACKAGE_PATH /opt/ros/$ROS_DISTRO/share
+
 @[if 'entrypoint_name' in locals()]@
 @[  if entrypoint_name]@
 @{

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -42,13 +42,10 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
 
-# install bootstrap tools
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    python3-rosdep \
-    python3-rosinstall \
-    python3-vcstools \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version=version,
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -1,0 +1,100 @@
+@(TEMPLATE(
+    'snippet/add_generated_comment.Dockerfile.em',
+    user_name=user_name,
+    tag_name=tag_name,
+    source_template_name=template_name,
+))@
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    template_packages=template_packages,
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+    base_image=base_image,
+    maintainer_name=maintainer_name,
+))@
+@(TEMPLATE(
+    'snippet/setup_tzdata.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
+@{
+template_dependencies = [
+    'dirmngr',
+    'gnupg2',
+    'lsb-release',
+]
+# add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
+}@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=template_dependencies,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
+@
+# setup ros2 keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python3-rosdep \
+    python3-rosinstall \
+    python3-vcstools \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+@[if 'pip3_install' in locals()]@
+@[  if pip3_install]@
+# install python packages
+RUN pip3 install -U \
+    @(' \\\n    '.join(pip3_install))@
+
+@[  end if]@
+@[end if]@
+
+# install ros2 packages
+ENV ROS_DISTRO @ros2distro_name
+RUN mkdir -p /opt/ros/$ROS_DISTRO
+ENV ROS2_BINARY_URL @ros2_binary_url
+RUN wget -q $ROS2_BINARY_URL -O - | \
+    tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
+
+# install dependencies
+RUN apt-get update && rosdep install -y \
+    --from-paths /opt/ros/$ROS_DISTRO/share \
+    --ignore-src \
+    --rosdistro $ROS_DISTRO \
+    --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers" \
+    && rm -rf /var/lib/apt/lists/*
+
+@[if 'entrypoint_name' in locals()]@
+@[  if entrypoint_name]@
+@{
+entrypoint_file = entrypoint_name.split('/')[-1]
+}@
+# setup entrypoint
+COPY ./@entrypoint_file /
+
+ENTRYPOINT ["/@entrypoint_file"]
+@[  end if]@
+@[end if]@
+@{
+cmds = [
+'bash',
+]
+}@
+CMD ["@(' && '.join(cmds))"]

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -94,7 +94,7 @@ RUN rosdep update
 @[end if]@
 @
 # install setup files
-RUN apt-get update && apt install -q -y \
+RUN apt-get update && apt-get install -q -y \
     ros-$ROS_DISTRO-ros-workspace \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -77,8 +77,8 @@ RUN wget -q $ROS2_BINARY_URL -O - | \
 RUN apt-get update && rosdep install -y \
     --from-paths /opt/ros/$ROS_DISTRO/share \
     --ignore-src \
-    --rosdistro $ROS_DISTRO \
-    --skip-keys "console_bridge fastcdr fastrtps libopensplice69 rti-connext-dds-5.3.1 urdfdom_headers" \
+    --skip-keys " \
+      @(' \\\n      '.join(skip_keys))@ " \
     && rm -rf /var/lib/apt/lists/*
 
 @[if 'entrypoint_name' in locals()]@

--- a/docker_templates/templates/docker_images_ros2/nightly/ros_entrypoint.sh
+++ b/docker_templates/templates/docker_images_ros2/nightly/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"


### PR DESCRIPTION
Rebased and modified version of https://github.com/osrf/docker_templates/pull/49

This PR includes the commits of https://github.com/osrf/docker_templates/pull/51 https://github.com/osrf/docker_templates/pull/52 https://github.com/osrf/docker_templates/pull/53 https://github.com/osrf/docker_templates/pull/54
It builds on top of the commits from #49 and will replace #49 

Once the PR it depends on it'll be rebased to include only the following changes

Relevant Changes:
- original commits from 49 adding the nightly template:
https://github.com/osrf/docker_templates/commit/99bf86637820011141587c5e9de76c1a2d8b6c51 and https://github.com/osrf/docker_templates/commit/7331d8ec72f7ff9b73cfdb9cf8196a70f71c352e
- declare wget as template dependency: https://github.com/osrf/docker_templates/commit/56835e2ecd5ac353918a41e322b1b6b99819ee7c
- use template to install bootstrapping packages https://github.com/osrf/docker_templates/commit/1c4ec0ddc3bbe043bcd9e9b6f660d6d123233389
- make ROS2_BINARY_URL a build arg https://github.com/osrf/docker_templates/commit/d9b447624f27b0241be138f3c8d6a1b52377cc64
- provide mechanism to add rosdep rule files via rosdep_override: https://github.com/osrf/docker_templates/commit/4ccbd6166d8ad68e3122db57ad9429aa7df5faab
- use snippet to invoke rosdep install https://github.com/osrf/docker_templates/commit/4ccbd6166d8ad68e3122db57ad9429aa7df5faab
- install `ros-ROS_DISTRO-ros-workspace` package to get setup files https://github.com/osrf/docker_templates/commit/4ccbd6166d8ad68e3122db57ad9429aa7df5faab
- set ROS_PACKAGE_PATH to trick rosdep into finding ROS2 packages https://github.com/osrf/docker_templates/commit/b2c1ea934d8b79e5bc74e3f0e990b541a04cdb85


Resulting Dockerfile available at https://github.com/osrf/docker_images/pull/247