### PR TITLE
missing empy delimiter

### DIFF
--- a/docker_templates/templates/snippet/vcs_import.Dockerfile.em
+++ b/docker_templates/templates/snippet/vcs_import.Dockerfile.em
@@ -1,8 +1,10 @@
 @[if 'vcs' in locals()]@
 @[  if vcs]@
 @[    for i, (imports_name, imports) in enumerate(vcs.items())]@
+@{
 if imports['repos'] is None:
     imports['repos'] = "https://raw.githubusercontent.com/ros2/ros2/$ROS_DISTRO/ros2.repos"
+}@
 RUN wget @(imports['repos']) \
     && vcs import @(ws) < @(imports['repos'].split('/')[-1])
 @[    end for]@


### PR DESCRIPTION
Follow up of #53 

Otherwise template expansion fails with
```
AttributeError in template 'snippet/vcs_import.Dockerfile.em': 'NoneType' object has no attribute 'split'
```