### PR TITLE
Rotate keys for ros2 apt repos

### DIFF
--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -36,7 +36,7 @@ if 'pip3_install' in locals():
 ))@
 @
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list

--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -29,7 +29,7 @@ if 'pip3_install' in locals():
 ))@
 @
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -37,7 +37,7 @@ if 'pip3_install' in locals():
 ))@
 @
 # setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-testing.list


### PR DESCRIPTION
Update ros2 templates with latest signing key for ROS 2 apt repositories.
Context: https://discourse.ros.org/t/key-rotation-for-ros-2-apt-repositories/9363