### PR TITLE
Rotate ROS repository keys.

### DIFF
--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -34,7 +34,7 @@ template_dependencies = [
 ))@
 @
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # setup sources.list
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list


### PR DESCRIPTION
This should be merged and run after the ROS 1 sync that will rotate keys. It's the same new key as used for the ROS 2 repositories.

https://discourse.ros.org/t/security-issue-on-ros-build-farm/9342/8