### PR TITLE
Legacy ROS releases have been moved to the snapshots repo.

### DIFF
--- a/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
@@ -29,10 +29,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 @[  end if]@
 @[end if]@
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AD19BAB3CBF125EA
 
 # setup sources.list
-RUN echo "deb http://packages.ros.org/ros/ubuntu @os_code_name main" > /etc/apt/sources.list.d/ros-latest.list
+RUN echo "deb http://snapshots.ros.org/@rosdistro_name/final/@os_name @os_code_name main" > /etc/apt/sources.list.d/ros-snapshots.list
 
 # setup environment
 RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
The changes described in https://discourse.ros.org/t/security-issue-on-ros-build-farm/9342/8 will remove unsupported ROS releases from the live ROS repositories. The packages for these releases are being migrated to the ROS Snapshots repositories.

This switches legacy releases to adding the snapshots key and using the snapshots http format for final snapshots.