### PR TITLE
use ros_buildfarm old_release_set.Dockerfile.em

### DIFF
--- a/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
@@ -14,8 +14,12 @@
     maintainer_name=maintainer_name,
 ))@
 
-# setup source.list to old-releases
-RUN sed -i -e 's/archive/old-releases/g' /etc/apt/sources.list
+@(TEMPLATE(
+    'snippet/old_release_set.Dockerfile.em',
+    template_packages=template_packages,
+    os_name=os_name,
+    os_code_name=os_code_name,
+))@
 
 @[if 'packages' in locals()]@
 @[  if packages]@


### PR DESCRIPTION
~~Requires https://github.com/ros-infrastructure/ros_buildfarm/pull/637~~

Now that this template will start being used on more recent distros as well as non Ubuntu distros. We should not apply the sed for `old-releases` unconditionnaly.

This PR switches to using the [template used by the ros_buildfarm](https://github.com/ros-infrastructure/ros_buildfarm/blob/fe6ee2ad3ec318879a3b9e2831d2a2508430c00f/ros_buildfarm/templates/snippet/old_release_set.Dockerfile.em) instead

@nuclearsandwich FYI