### PR TITLE
use full apt key fingerprint for snapshots repository

### DIFF
--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -14,7 +14,7 @@ if isDistroEOL(ros_distro_name, os_code_name):
         'final',
         str(os_name)
     )
-    repo_key = 'AD19BAB3CBF125EA'
+    repo_key = '4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA'
     source_suffix = 'snapshots'
 else:
     repo_key = 'C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'


### PR DESCRIPTION
As per docker guidelines: https://github.com/docker-library/official-images/pull/6401#issuecomment-517497515

Tested on trusty and boxturtle/lucid

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>