### PR TITLE
add ros bouncy to eol list

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -27,6 +27,7 @@ def isDistroEOL(ros_distro_name, os_distro_name):
         'lunar',
         # ROS 2
         'ardent',
+        'bouncy',
     ]
     eol_base_images = [
         # Ubuntu


### PR DESCRIPTION
Bouncy is now EOL and its packages available on the snapshots repository https://github.com/osrf/docker_images/pull/301#issuecomment-518346213

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>