### PR TITLE
revert ROS_PACKAGE_PATH hack allowing rosdep to find the ros2 packages

### DIFF
--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -107,10 +107,6 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 
 @[end if]@
 @
-# FIXME Remove this once rosdep detects ROS 2 packages https://github.com/ros-infrastructure/rosdep/issues/660
-# ignore installed rosdep keys
-ENV ROS_PACKAGE_PATH /opt/ros/$ROS_DISTRO/share
-
 @[if 'entrypoint_name' in locals()]@
 @[  if entrypoint_name]@
 @{


### PR DESCRIPTION
similar to https://github.com/osrf/docker_images/pull/326

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>