### PR TITLE
Build ros_workspace instead of installing deb

### DIFF
--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -22,6 +22,7 @@
 template_dependencies = [
     'cmake',
     'dirmngr',
+    'git',
     'gnupg2',
     'lsb-release',
     'wget',

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -69,14 +69,14 @@ RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
 
 # Overwrite setup scripts with ones that point to /opt/ros/$ROS_DISTRO
-RUN mkdir -p /tmp/rosws/build \
- && cd /tmp/rosws \
+RUN mkdir -p /tmp/dir/build \
+ && cd /tmp/dir \
  && git clone --depth 1 https://github.com/ros2/ros_workspace.git -b latest \
- && cd /tmp/rosws/build \
+ && cd /tmp/dir/build \
  && COLCON_CURRENT_PREFIX=/opt/ros/$ROS_DISTRO . /opt/ros/$ROS_DISTRO/local_setup.sh \
  && cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO ../ros_workspace \
  && make install \
- && rm -r /tmp/rosws
+ && rm -r /tmp/dir
 
 # bootstrap rosdep
 @[  if 'rosdistro_index_url' in rosdep]@

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -20,6 +20,7 @@
 ))@
 @{
 template_dependencies = [
+    'cmake',
     'dirmngr',
     'gnupg2',
     'lsb-release',
@@ -67,10 +68,14 @@ ARG ROS2_BINARY_URL=@ros2_binary_url
 RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
 
-# install setup files
-RUN apt-get update && apt-get install -q -y \
-    ros-$ROS_DISTRO-ros-workspace \
-    && rm -rf /var/lib/apt/lists/*
+# Overwrite setup scripts with ones that point to /opt/ros/$ROS_DISTRO
+RUN mkdir -p /tmp/rosws \
+ && cd /tmp/rosws \
+ && git clone --depth 1 https://github.com/ros2/ros_workspace.git -b latest \
+ && COLCON_CURRENT_PREFIX=/opt/ros/$ROS_DISTRO . /opt/ros/$ROS_DISTRO/local_setup.sh \
+ && cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO ./ros_workspace \
+ && make install \
+ && rm -r /tmp/rosws
 
 # bootstrap rosdep
 @[  if 'rosdistro_index_url' in rosdep]@

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -69,11 +69,12 @@ RUN wget -q $ROS2_BINARY_URL -O - | \
     tar -xj --strip-components=1 -C /opt/ros/$ROS_DISTRO
 
 # Overwrite setup scripts with ones that point to /opt/ros/$ROS_DISTRO
-RUN mkdir -p /tmp/rosws \
+RUN mkdir -p /tmp/rosws/build \
  && cd /tmp/rosws \
  && git clone --depth 1 https://github.com/ros2/ros_workspace.git -b latest \
+ && cd /tmp/rosws/build \
  && COLCON_CURRENT_PREFIX=/opt/ros/$ROS_DISTRO . /opt/ros/$ROS_DISTRO/local_setup.sh \
- && cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO ./ros_workspace \
+ && cmake -DCMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO ../ros_workspace \
  && make install \
  && rm -r /tmp/rosws
 


### PR DESCRIPTION
Fixes osrf/docker_images#331

This is an alternative thought of by @dirk-thomas.

Instead of using setup scripts from the `ros-eloquent-ros-workspace` debian package, it downloads and installs the latest version of `ros_workspace`. That way when there are changes to `ros_workspace` or the packages it depends on (`ament_package`, `ament_cmake_core`), the nightly version of those packages continues to be used.

More context/options here https://github.com/osrf/docker_templates/pull/55/files#r268011402