### PR TITLE
Reconcile templates and generated files + add nightly templates

### DIFF
--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -68,13 +68,9 @@ ENV LC_ALL C.UTF-8
     ros_version=ros_version,
 ))@
 
-# setup colcon mixin and metadata
-RUN colcon mixin add default \
-      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
-    colcon mixin update && \
-    colcon metadata add default \
-      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
-    colcon metadata update
+@(TEMPLATE(
+    'snippet/setup_colcon_mixin_metadata.Dockerfile.em',
+))@
 
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@

--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -71,13 +71,9 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 
-# setup colcon mixin and metadata
-RUN colcon mixin add default \
-      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
-    colcon mixin update && \
-    colcon metadata add default \
-      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
-    colcon metadata update
+@(TEMPLATE(
+    'snippet/setup_colcon_mixin_metadata.Dockerfile.em',
+))@
 
 # clone source
 ENV ROS2_WS @(ws)

--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -61,7 +61,10 @@ RUN pip3 install -U \
 
 @[  end if]@
 @[end if]@
-
+@(TEMPLATE(
+    'snippet/check_pytest_regression.Dockerfile.em',
+))@
+@
 # bootstrap rosdep
 @[if 'rosdep' in locals()]@
 @[  if 'rosdistro_index_url' in rosdep]@

--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -71,6 +71,14 @@ ENV ROSDISTRO_INDEX_URL @(rosdep['rosdistro_index_url'])
 RUN rosdep init \
     && rosdep update
 
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
 # clone source
 ENV ROS2_WS @(ws)
 RUN mkdir -p $ROS2_WS/src

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -97,6 +97,14 @@ RUN rosdep update
 
 @[end if]@
 @
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update
+
 @[if 'rosdep' in locals()]@
 @{
 if 'path' not in rosdep:

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -82,13 +82,9 @@ RUN mkdir -p /tmp/dir/build \
  && make install \
  && rm -r /tmp/dir
 
-# setup colcon mixin and metadata
-RUN colcon mixin add default \
-      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
-    colcon mixin update && \
-    colcon metadata add default \
-      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
-    colcon metadata update
+@(TEMPLATE(
+    'snippet/setup_colcon_mixin_metadata.Dockerfile.em',
+))@
 
 @[if 'rosdep' in locals()]@
 # bootstrap rosdep

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -64,7 +64,10 @@ RUN pip3 install -U \
 
 @[  end if]@
 @[end if]@
-
+@(TEMPLATE(
+    'snippet/check_pytest_regression.Dockerfile.em',
+))@
+@
 # install ros2 packages
 ENV ROS_DISTRO @ros2distro_name
 RUN mkdir -p /opt/ros/$ROS_DISTRO

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_nightly_overlay.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_nightly_overlay.Dockerfile.em
@@ -1,0 +1,84 @@
+@(TEMPLATE(
+    'snippet/add_generated_comment.Dockerfile.em',
+    user_name=user_name,
+    tag_name=tag_name,
+    source_template_name=template_name,
+))@
+@(TEMPLATE(
+    'snippet/from_base_image.Dockerfile.em',
+    template_packages=template_packages,
+    os_name=os_name,
+    os_code_name=os_code_name,
+    arch=arch,
+    base_image=base_image,
+    maintainer_name=maintainer_name,
+))@
+@{
+template_dependencies = []
+# add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
+if 'pip3_install' in locals():
+    if isinstance(pip3_install, list) and pip3_install != []:
+        template_dependencies.append('python3-pip')
+}@
+@[if 'env_before' in locals()]@
+
+@[  for env_var, env_val in env_before.items()]@
+ENV @(env_var) @(env_val)
+@[  end for]@
+@[end if]@
+@(TEMPLATE(
+    'snippet/install_upstream_package_list.Dockerfile.em',
+    packages=template_dependencies,
+    upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
+))@
+@
+
+@[if 'pip3_install' in locals()]@
+@[  if pip3_install]@
+# install python packages
+RUN pip3 install -U \
+    @(' \\\n    '.join(pip3_install))@
+
+@[  end if]@
+@[end if]@
+@
+@[if 'rosdep' in locals()]@
+# bootstrap rosdep
+RUN rosdep update
+
+@{
+if 'path' not in rosdep:
+  rosdep['path'] = '/opt/ros/$ROS_DISTRO/share'
+if 'skip_keys' not in rosdep:
+  rosdep['skip_keys'] = []
+}@
+# install dependencies
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
+    && apt-get update \
+    && rosdep install -y \
+    --from-paths @(rosdep['path']) \
+    --ignore-src \
+    --skip-keys " \
+      @(' \\\n      '.join(rosdep['skip_keys']))@ " \
+    && rm -rf /var/lib/apt/lists/*
+
+@[end if]@
+@
+@[if 'env_after' in locals()]@
+
+# set up environment
+@[  for env_var, env_val in env_after.items()]@
+ENV @(env_var) @(env_val)
+@[  end for]@
+@[end if]@
+@[if 'entrypoint_name' in locals()]@
+@[  if entrypoint_name]@
+@{
+entrypoint_file = entrypoint_name.split('/')[-1]
+}@
+# setup entrypoint
+COPY ./@entrypoint_file /
+
+ENTRYPOINT ["/@entrypoint_file"]
+@[  end if]@
+@[end if]@

--- a/docker_templates/templates/snippet/check_pytest_regression.Dockerfile.em
+++ b/docker_templates/templates/snippet/check_pytest_regression.Dockerfile.em
@@ -1,0 +1,5 @@
+# This is a workaround for pytest not found causing builds to fail
+# Following RUN statements tests for regression of https://github.com/ros2/ros2/issues/722
+RUN pip3 freeze | grep pytest \
+    && python3 -m pytest --version
+

--- a/docker_templates/templates/snippet/setup_colcon_mixin_metadata.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_colcon_mixin_metadata.Dockerfile.em
@@ -1,0 +1,7 @@
+# setup colcon mixin and metadata
+RUN colcon mixin add default \
+      https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml && \
+    colcon mixin update && \
+    colcon metadata add default \
+      https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
+    colcon metadata update


### PR DESCRIPTION
The source and nightly images started diverging significantly from the templates, and the nightly-rmw* images dont have a template of their own.

New snppets:
- setup up colcon mixin and metadata
- test that pytest is found

Templates now take `env_before` and `env_after` to pass env vars that the template should define


diff after this PR with images that will land on master
```diff
diff --git a/ros2/nightly/nightly/Dockerfile b/ros2/nightly/nightly/Dockerfile
index a04e35c..c2a7bc5 100644
--- a/ros2/nightly/nightly/Dockerfile
+++ b/ros2/nightly/nightly/Dockerfile
@@ -105,15 +105,9 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
       rti-connext-dds-5.3.1" \
     && rm -rf /var/lib/apt/lists/*
 
-# FIXME Remove this once rosdep detects ROS 2 packages https://github.com/ros-infrastructure/rosdep/issues/660
-# ignore installed rosdep keys
+# setup environment
 ENV ROS_PACKAGE_PATH /opt/ros/$ROS_DISTRO/share
 
-# FIXME Remove this once ament_export_interfaces respects COLCON_CURRENT_PREFIX https://github.com/ament/ament_cmake/issues/173
-#Workaround hard coded paths in nightly tarball setup scripts
-ARG UPSTREAM_CI_WS=/home/jenkins-agent/workspace/packaging_linux/ws
-RUN mkdir -p $UPSTREAM_CI_WS && ln -s /opt/ros/$ROS_DISTRO $UPSTREAM_CI_WS/install
-
 # setup entrypoint
 COPY ./ros_entrypoint.sh /

```
I kept thos manual changes as they are expected to be temporary and dont belong in the tmeplate. Can be added to the templates if preferred