### PR TITLE
no install recommends for all apt calls

### DIFF
--- a/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
@@ -36,7 +36,7 @@ ENV TZ @timezone
 RUN rosdep init
 
 # install requested metapackage
-RUN apt-get update && apt-get install -q -y @(' '.join(packages))@
+RUN apt-get update && apt-get install -q -y --no-install-recommends @(' '.join(packages))@
 
 ENV ROS_DISTRO @(rosdistro)@
 # TODO source rosdistro setup file automatically on entry

--- a/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -20,6 +20,6 @@
 ))@
 @
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     @(' \\\n    '.join(gazebo_packages))@  \
     && rm -rf /var/lib/apt/lists/*

--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -39,7 +39,7 @@ RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     @(' \\\n    '.join(gazebo_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -25,7 +25,7 @@ template_dependencies = [
 ))@
 @
 # install gazebo packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     @(' \\\n    '.join(gazebo_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -13,7 +13,6 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@
 @(TEMPLATE(
     'snippet/old_release_set.Dockerfile.em',
     template_packages=template_packages,
@@ -47,19 +46,11 @@ template_dependencies = [
     ros_version=ros_version,
 ))@
 
-@(TEMPLATE(
-    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
-))@
-
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO @rosdistro_name
-# bootstrap rosdep
-RUN rosdep init && \
-  rosdep update --rosdistro $ROS_DISTRO
 
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -62,7 +62,7 @@ RUN rosdep init && \
   rosdep update --rosdistro $ROS_DISTRO
 
 # install ros packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -13,15 +13,27 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
+
 @(TEMPLATE(
     'snippet/install_upstream_package_list.Dockerfile.em',
     packages=[],
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @
+@[if 'bootstrap_ros_tools' in locals()]@
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version=ros_version,
+))@
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+@[end if]@
+@
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
-
 # install ros packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros_packages))@  \

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -23,7 +23,7 @@
 @[  if ros_packages]@
 
 # install ros packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -80,7 +80,7 @@ RUN pip3 install -U \
 @[end if]@
 @
 # install ros2 packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros2_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -13,7 +13,6 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
-@
 @(TEMPLATE(
     'snippet/old_release_set.Dockerfile.em',
     template_packages=template_packages,
@@ -52,23 +51,11 @@ if 'pip3_install' in locals():
     ros_version=ros_version,
 ))@
 
-@(TEMPLATE(
-    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
-))@
-
 # setup environment
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO @ros2distro_name
-# bootstrap rosdep
-RUN rosdep init && \
-  rosdep update --rosdistro $ROS_DISTRO
-
-@(TEMPLATE(
-    'snippet/setup_colcon_mixin_metadata.Dockerfile.em',
-))@
 
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@

--- a/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
@@ -37,7 +37,7 @@ RUN pip3 install -U \
 @[if 'ros2_packages' in locals()]@
 @[  if ros2_packages]@
 # install ros2 packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros2_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
@@ -13,6 +13,7 @@
     base_image=base_image,
     maintainer_name=maintainer_name,
 ))@
+
 @{
 template_dependencies = []
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
@@ -25,6 +26,22 @@ if 'pip3_install' in locals():
     packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
+@
+@[if 'bootstrap_ros_tools' in locals()]@
+@(TEMPLATE(
+    'snippet/install_ros_bootstrap_tools.Dockerfile.em',
+    ros_version=ros_version,
+))@
+
+# bootstrap rosdep
+RUN rosdep init && \
+  rosdep update --rosdistro $ROS_DISTRO
+
+@(TEMPLATE(
+    'snippet/setup_colcon_mixin_metadata.Dockerfile.em',
+))@
+
+@[end if]@
 @
 @[if 'pip3_install' in locals()]@
 @[  if pip3_install]@

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -48,7 +48,7 @@ ENV ROS2_DISTRO @ros2distro_name
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
 # install ros packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y \
 @[if 'ros2_packages' in locals()]@
 @[  if ros2_packages]@
 # install ros2 packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     @(' \\\n    '.join(ros2_packages))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -1,6 +1,7 @@
 @{
 if int(ros_version) == 2:
     package_list = [
+        'build-essential',
         'git',
         'python3-colcon-common-extensions',
         'python3-colcon-mixin',
@@ -9,6 +10,7 @@ if int(ros_version) == 2:
     ]
 else:
     package_list = [
+        'build-essential',
         'python-rosdep',
         'python-rosinstall',
         'python-vcstools',

--- a/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_upstream_package_list.Dockerfile.em
@@ -9,7 +9,7 @@ if isinstance(packages, list):
 @[  if packages != []]@
 
 # install packages
-RUN apt-get update && apt-get install -q -y \
+RUN apt-get update && apt-get install -q -y --no-install-recommends \
     @(' \\\n    '.join(sorted(packages)))@  \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker_templates/templates/snippet/setup_tzdata.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_tzdata.Dockerfile.em
@@ -23,5 +23,7 @@ releases_with_configured_tzdata = [
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
     ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && apt-get install -q -y tzdata && rm -rf /var/lib/apt/lists/*
+    apt-get update && \
+    apt-get install -q -y --no-install-recommends tzdata && \
+    rm -rf /var/lib/apt/lists/*
 @[end if]@


### PR DESCRIPTION
https://discourse.ros.org/t/generating-dev-and-runtime-artefacts-from-ros-packages/12448 reminded me of an old branch adding the use of `no-install-recommends`. While not providing significant improvement it would still reduce image size by about 10%.

This is what is used elsewhere, e.g. for [ROS 2 CI](https://github.com/ros2/ci/blob/36681140b6c4409d5a0532e4e7352ac75ca964e0/linux_docker_resources/Dockerfile)

|             Name              |  Recommends  |   No recommends    |
| ----------------------------- | ------------ | ------------------ |
| melodic-desktop-full-bionic   |   2.9GB      |       2.62GB       |
| melodic-desktop-bionic        |   2.09GB     |       1.85GB       |
| melodic-ros-base-bionic       |   1.26GB     |       1.14GB       |
| melodic-ros-core-bionic       |   1.03GB     |       911MB        |
| ----------------------------- | ------------ | ------------------ |
| eloquent-ros1-bridge          |   1.4GB      |       1.27GB       | 
| eloquent-desktop-bionic       |   2.6GB      |       2.36GB       |
| eloquent-ros-base-bionic      |   851MB      |       720MB        |
| eloquent-ros-core-bionic      |   826MB      |       695MB        |

Ideally we would be able to pass something similar to rosdep and reduce the nightly image size. If we could also tell rosdep to install only the `exec` and `build_export` depends we could reduce the image size further


---

One thing unexpected and maybe worth further investigation is how is eloquent-desktop so much bigger than melodic-desktop while desktop includes a lot less features in ROS 2 than ROS 1