### PR TITLE
fixup commit_path to avoid false positives

### DIFF
--- a/docker_templates/library.py
+++ b/docker_templates/library.py
@@ -35,8 +35,6 @@ def parse_manifest(manifest, repo, repo_name):
             # For each os code name supported
             for os_code_name, os_code_data in list(os_data['os_code_names'].items()):
                 print('os_code_name: ', os_code_name)
-                commit_path = os.path.join(repo_name, release_name, os_name, os_code_name)
-                commit_sha = latest_commit_sha(repo, commit_path)
                 if os_code_data['tag_names']:
                     at_least_one_tag = True
                     for tag_name, tag_data in os_code_data['tag_names'].items():
@@ -49,11 +47,15 @@ def parse_manifest(manifest, repo, repo_name):
                                 os_name=os_name,
                                 os_code_name=os_code_name)
                             tags.append(alias)
+                        commit_path = os.path.join(
+                            repo_name, release_name,
+                            os_name, os_code_name, tag_name)
+                        commit_sha = latest_commit_sha(repo, commit_path)
                         print('tags: ', tags)
                         tag_data['Tags'] = tags
                         tag_data['Architectures'] = os_code_data['archs']
                         tag_data['GitCommit'] = commit_sha
-                        tag_data['Directory'] = os.path.join(commit_path, tag_name)
+                        tag_data['Directory'] = commit_path
         if not at_least_one_tag:
             del manifest['release_names'][release_name]
 


### PR DESCRIPTION
Currently the path used for checking commit hashes is the base path of the distro/arch e.g.
`ros/eloquent/ubuntu/bionic` and this same path is used for all tags in the distro.
This leads to unnecessary docker library update when the latest commits didn't touch any of the tags part of the official library.
e.g. for ROS 2 when the ros1-bridge images are updated there is no need to update the manifest as the ros1bridge image is not part of the official library.

With this PR the sha is now checked in the folder of each tag's directory