### PR TITLE
don't pass rosdistro when using empty index

### DIFF
--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -97,7 +97,7 @@ RUN echo "yaml file:///etc/ros/rosdep/@rule_file" | \
     mv temp /etc/ros/rosdep/sources.list.d/20-default.list
 @[    end for]@
 @[  end if]@
-RUN rosdep update --rosdistro $ROS_DISTRO
+RUN rosdep update
 
 @{
 if 'path' not in rosdep:

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_nightly_overlay.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_nightly_overlay.Dockerfile.em
@@ -44,7 +44,7 @@ RUN pip3 install -U \
 @
 @[if 'rosdep' in locals()]@
 # bootstrap rosdep
-RUN rosdep update --rosdistro $ROS_DISTRO
+RUN rosdep update
 
 @{
 if 'path' not in rosdep:


### PR DESCRIPTION
As of https://github.com/osrf/docker_images/pull/307 the `ros2:nightly*` images use an empty rosdistro index to prevent users from installing released ROS packages via rosdep.

As a consequence, specifying which rosdistro to update brings no benefit as there aren't any distro in the index. Since [rosdep 0.19.0](https://github.com/ros-infrastructure/rosdep/releases/tag/0.19.0), `rosdep update` fails if the `rosdistro` passed to it is unknown.

To fix the build of the nightly images this removes the `--rosdistro` from `rosdep update` in all the nightly images