### PR TITLE
explicitly install needed build tools rather than installing build-essential

### DIFF
--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -1,7 +1,11 @@
 @{
 if int(ros_version) == 2:
     package_list = [
-        'build-essential',
+        'cmake',
+        'gcc',
+        'g++',
+        'libc6-dev',
+        'make',
         'git',
         'python3-colcon-common-extensions',
         'python3-colcon-mixin',
@@ -10,7 +14,11 @@ if int(ros_version) == 2:
     ]
 else:
     package_list = [
-        'build-essential',
+        'cmake',
+        'gcc',
+        'g++',
+        'libc6-dev',
+        'make',
         'python-rosdep',
         'python-rosinstall',
         'python-vcstools',


### PR DESCRIPTION
Based on feedback from https://github.com/docker-library/official-images/pull/8031#issuecomment-631764428

Impact on current images:
For all ubuntu images -> no impact as `pkg-config` depends on `dpkg-dev` on xenial and bionic
For debian stretch images:
```
The following NEW packages will be installed:
  build-essential bzip2 dpkg-dev patch xz-utils
0 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
Need to get 2028 kB of archives.
After this operation, 2876 kB of additional disk space will be used.
```

For future images -> expected impact is minor as ROS 1 and ROS 2 rely on libconsole-bridge-dev that depends on pkg-config.

---

It should be safe to do this change, it will have the advantage of being explicit on the packages we expect people to need for building packages.
We could potentially significant space in the future by requesting console_bridge to make the dependency on pkg-config optional.