### PR TITLE
Remove redundant directives in ros1 bridge template

### DIFF
--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -70,13 +70,3 @@ entrypoint_file = entrypoint_name.split('/')[-1]
 }@
 # setup entrypoint
 COPY ./@entrypoint_file /
-
-ENTRYPOINT ["/@entrypoint_file"]
-@{
-cmds = [
-'bash',
-]
-}@
-CMD ["@(' && '.join(cmds))"]
-@[  end if]@
-@[end if]@

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -69,6 +69,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 entrypoint_file = entrypoint_name.split('/')[-1]
 }@
 # setup entrypoint
-COPY ./@entrypoint_file /	
+COPY ./@entrypoint_file /
 @[  end if]@	
 @[end if]@

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -69,4 +69,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 entrypoint_file = entrypoint_name.split('/')[-1]
 }@
 # setup entrypoint
-COPY ./@entrypoint_file /
+COPY ./@entrypoint_file /	
+@[  end if]@	
+@[end if]@


### PR DESCRIPTION
As it keeps the same default entry point and command