### PR TITLE
inject sha256 labels for all target packages

### DIFF
--- a/docker_templates/packages.py
+++ b/docker_templates/packages.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
 import string
 import re
 import urllib.request
@@ -29,11 +30,11 @@ packagePatternTemplateLookup = {
 }
 
 indexUrlTemplateLookup = {
-    'gazebo_packages':  string.Template('http://packages.osrfoundation.org/gazebo/$os_name-$release/dists/$os_code_name/main/binary-$arch/Packages'),
-    'ros_packages':     string.Template('http://packages.ros.org/ros/ubuntu/dists/$os_code_name/main/binary-$arch/Packages'),
-    'ros2_packages':    string.Template('http://packages.ros.org/ros2/ubuntu/dists/$os_code_name/main/binary-$arch/Packages'),
-    'ros_packages_snapshots':    string.Template('http://snapshots.ros.org/$rosdistro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages'),
-    'ros2_packages_snapshots':    string.Template('http://snapshots.ros.org/$ros2distro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages'),
+    'gazebo_packages':  string.Template('http://packages.osrfoundation.org/gazebo/$os_name-$release/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros_packages':     string.Template('http://packages.ros.org/ros/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros2_packages':    string.Template('http://packages.ros.org/ros2/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros_packages_snapshots':    string.Template('http://snapshots.ros.org/$rosdistro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros2_packages_snapshots':    string.Template('http://snapshots.ros.org/$ros2distro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
 }
 
 packageNameVersionTemplateLookup = {
@@ -54,7 +55,7 @@ def getPackageIndex(data, package_index_url):
     # Download package index
     req = urllib.request.Request(package_index_url)
     with urllib.request.urlopen(req) as response:
-        package_index = response.read().decode('utf-8')
+        package_index = gzip.decompress(response.read()).decode('utf-8')
 
     return package_index
 

--- a/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_drcsim_image.Dockerfile.em
@@ -41,11 +41,11 @@ RUN . /etc/os-release \
 @[if 'gazebo_packages' in locals()]@
 @[  if gazebo_packages]@
 
-# install ros packages
-RUN apt-get update && apt-get install -y \
-    @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='gazebo',
+    packages=gazebo_packages,
+))@
 @[  end if]@
 @[end if]@
 @[if 'entrypoint_name' in locals()]@

--- a/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzclient_image.Dockerfile.em
@@ -19,7 +19,8 @@
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @
-# install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='gazebo',
+    packages=gazebo_packages,
+))@

--- a/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserverX_image.Dockerfile.em
@@ -60,10 +60,11 @@ ENV LC_ALL C.UTF-8
 RUN rosdep init \
     && rosdep update
 
-# install ros packages
-RUN apt-get update && apt-get install -y \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros',
+    packages=ros_packages,
+))@
 @[  end if]@
 @[end if]@
 
@@ -77,10 +78,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
-# install gazebo packages
-RUN apt-get update && apt-get install -q -y \
-    @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='gazebo',
+    packages=gazebo_packages,
+))@
 @[end if]@
 @[end if]@
 

--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -38,11 +38,11 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD8
 RUN . /etc/os-release \
     && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
 
-# install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='gazebo',
+    packages=gazebo_packages,
+))@
 # setup environment
 EXPOSE 11345
 

--- a/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzweb_image.Dockerfile.em
@@ -24,11 +24,11 @@ template_dependencies = [
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 @
-# install gazebo packages
-RUN apt-get update && apt-get install -q -y --no-install-recommends \
-    @(' \\\n    '.join(gazebo_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='gazebo',
+    packages=gazebo_packages,
+))@
 # clone gzweb
 ENV GZWEB_WS /root/gzweb
 RUN hg clone https://bitbucket.org/osrf/gzweb $GZWEB_WS

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -52,11 +52,11 @@ ENV LC_ALL C.UTF-8
 
 ENV ROS_DISTRO @rosdistro_name
 
-# install ros packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros',
+    packages=ros_packages,
+))@
 @[if 'entrypoint_name' in locals()]@
 @[  if entrypoint_name]@
 @{

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -34,10 +34,10 @@ RUN rosdep init && \
 @
 @[if 'ros_packages' in locals()]@
 @[  if ros_packages]@
-# install ros packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros',
+    packages=ros_packages,
+))@
 @[  end if]@
 @[end if]@

--- a/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_legacy/create_ros_core_image.Dockerfile.em
@@ -48,7 +48,7 @@ ENV LANG en_US.UTF-8
 # install ros packages
 ENV ROS_DISTRO @rosdistro_name
 RUN apt-get update && apt-get install -y \
-    @(' \\\n    '.join(ros_packages))@  \
+    @(' \\\n    '.join('{name}{version}'.format(**p) for p in ros_packages))@  \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /var/lib/apt/lists/partial
 

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -66,11 +66,11 @@ RUN pip3 install -U \
 @[  end if]@
 @[end if]@
 @
-# install ros2 packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros2_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros2',
+    packages=ros2_packages,
+))@
 @[if 'entrypoint_name' in locals()]@
 @[  if entrypoint_name]@
 @{

--- a/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
@@ -52,13 +52,11 @@ RUN pip3 install -U \
 @[  end if]@
 @[end if]@
 @[if 'ros2_packages' in locals()]@
-@[  if ros2_packages]@
-# install ros2 packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros2_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[  end if]@
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros2',
+    packages=ros2_packages,
+))@
 @[end if]@
 @[if 'entrypoint_name' in locals()]@
 @[  if entrypoint_name]@

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -45,6 +45,7 @@ RUN pip3 install -U \
 
 ENV ROS1_DISTRO @rosdistro_name
 ENV ROS2_DISTRO @ros2distro_name
+
 @[if 'ros_packages' in locals()]@
 @(TEMPLATE(
     'snippet/label_and_install_package_list.Dockerfile.em',

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -46,22 +46,18 @@ RUN pip3 install -U \
 ENV ROS1_DISTRO @rosdistro_name
 ENV ROS2_DISTRO @ros2distro_name
 @[if 'ros_packages' in locals()]@
-@[  if ros_packages]@
-# install ros packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[  end if]@
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros',
+    packages=ros_packages,
+))@
 @[end if]@
 @[if 'ros2_packages' in locals()]@
-@[  if ros2_packages]@
-# install ros2 packages
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    @(' \\\n    '.join(ros2_packages))@  \
-    && rm -rf /var/lib/apt/lists/*
-
-@[  end if]@
+@(TEMPLATE(
+    'snippet/label_and_install_package_list.Dockerfile.em',
+    group='ros2',
+    packages=ros2_packages,
+))@
 @[end if]@
 @[if 'downstream_packages' in locals()]@
 @[  if downstream_packages]@

--- a/docker_templates/templates/snippet/label_and_install_package_list.Dockerfile.em
+++ b/docker_templates/templates/snippet/label_and_install_package_list.Dockerfile.em
@@ -1,0 +1,10 @@
+@[if packages]@
+# label @group packages
+LABEL @(' \\\n      '.join('sha256.{name}={sha256}'.format(**p) for p in packages))@
+
+
+# install @group packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    @(' \\\n    '.join('{name}{version}'.format(**p) for p in packages))@  \
+    && rm -rf /var/lib/apt/lists/*
+@[end if]


### PR DESCRIPTION
This PR addresses the SHA256 injection as proposed in https://github.com/osrf/docker_images/issues/376

* package handling functions have been refactored (breaks API) to parse the data only once
* getPackageVersions returns list of  `dict(name, version, sha256)` instead string
* Dockerfile templates have been updated to use a common snippet
* whitespace still differs a little bit
* all packages get installed with `apt-get install -y --no-install-recommends`

I can update the common snippet to take a list of ` apt`arguments, if needed.


