### PR TITLE
fix gazebo package lookup resulting in the right shas being used

### DIFF
--- a/docker_templates/packages.py
+++ b/docker_templates/packages.py
@@ -26,7 +26,7 @@ version_pattern = r'(?<=Version: )\d+\.\d+\.\d+\-\d+'
 sha256_pattern = r'(?<=SHA256: )[0-9a-f]{64}'
 
 packagePatternTemplateLookup = {
-    'gazebo_packages':  string.Template(r'(\bPackage: gazebo$gazebo_version\n)(.*?(?:\r*\n{2}))'),
+    'gazebo_packages':  string.Template(r'(\bPackage: $package\n)(.*?(?:\r*\n{2}))'),
     'ros_packages':     string.Template(r'(\bPackage: ros-$rosdistro_name-$package\n)(.*?(?:\r*\n{2}))'),
     'ros2_packages':    string.Template(r'(\bPackage: ros-$ros2distro_name-$package\n)(.*?(?:\r*\n{2}))'),
 }


### PR DESCRIPTION
Before this the extracted sha was always the same for a given gazebo version. For example in https://github.com/osrf/docker_images/pull/467 the sha of the package `gazebo9` was used for all images and packages, even for package  `libgazebo9-dev`