### PR TITLE
EOL stretch and swap apt key and source list

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -52,5 +52,6 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         # Debian
         'wheezy',
         'jessie',
+        'stretch',
     ]
     return os_distro_name in eol_base_images or ros_distro_name in eol_ros_distros

--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -30,6 +30,7 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         'ardent',
         'bouncy',
         'crystal',
+        'eloquent',
     ]
     eol_base_images = [
         # Ubuntu

--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -27,12 +27,15 @@ if 'pip3_install' in locals():
     packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
-@
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-latest.list
+@(TEMPLATE(
+    'snippet/setup_ros_sources.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    ros2distro_name='rolling',
+    rosdistro_name='',
+    ros_version=ros_version,
+))@
 
 # setup environment
 ENV LANG C.UTF-8

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -37,12 +37,15 @@ if 'pip3_install' in locals():
     packages=template_dependencies,
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
-@
-# setup ros2 keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
-# setup sources.list
-RUN echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros2-testing.list
+@(TEMPLATE(
+    'snippet/setup_ros_sources.Dockerfile.em',
+    os_name=os_name,
+    os_code_name=os_code_name,
+    ros2distro_name=ros2distro_name,
+    rosdistro_name='',
+    ros_version=ros_version,
+))@
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',

--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -25,8 +25,8 @@ else:
     elif int(ros_version) == 2:
         repo_url = 'http://packages.ros.org/ros2/ubuntu'
 }@
-# setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys @(repo_key)
-
 # setup sources.list
 RUN echo "deb @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys @(repo_key)


### PR DESCRIPTION
- Add eloquent and debian stretch to EOL list
- Use "setup_ros_sources" snippet in ROS 2 images
- Modify "setup_ros_source" template to swap key setup and source.list

Required to generate files of PRs https://github.com/osrf/docker_images/pull/538  https://github.com/osrf/docker_images/pull/537 https://github.com/osrf/docker_images/pull/536 