### PR TITLE
add kinetic to the list of EOL distros

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -25,6 +25,7 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         'hydro',
         'indigo',
         'jade',
+        'kinetic',
         'lunar',
         # ROS 2
         'ardent',


### PR DESCRIPTION
As kinetic is now officially EOL: https://discourse.ros.org/t/kinetic-kame-officially-end-of-life/20394

There doesn't seem to be a final snapshot for kinetic yet so this PR cannot be merged for now. /cc @tfoote @nuclearsandwich 