### PR TITLE
add dashing to list of EOL distros

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -30,6 +30,7 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         'ardent',
         'bouncy',
         'crystal',
+        'dashing',
         'eloquent',
     ]
     eol_base_images = [


### PR DESCRIPTION
Dashing is now EOL: https://discourse.ros.org/t/new-packages-and-patch-release-for-ros-2-dashing-diademata-2021-06-10-final/20875