### PR TITLE
Add Galactic to EOL distros.

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -33,6 +33,7 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         'crystal',
         'dashing',
         'eloquent',
+        'galactic',
     ]
     eol_base_images = [
         # Ubuntu


### PR DESCRIPTION
Galactic is EOL and the final snapshot for it has been published:

http://snapshots.ros.org/galactic/final/ubuntu/