### PR TITLE
Using rosdistro infos to get ros version, python version and eol status

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -13,28 +13,9 @@
 # limitations under the License.
 
 
-def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
-    eol_ros_distros = [
-        # ROS 1
-        'boxturtle',
-        'cturtle',
-        'diamondback',
-        'electric',
-        'fuerte',
-        'groovy',
-        'hydro',
-        'indigo',
-        'jade',
-        'kinetic',
-        'lunar',
-        # ROS 2
-        'ardent',
-        'bouncy',
-        'crystal',
-        'dashing',
-        'eloquent',
-        'galactic',
-    ]
+def isDistroEOL(*, ros_distro_status=None, os_distro_name=None):
+    if ros_distro_status == "end-of-life":
+        return True
     eol_base_images = [
         # Ubuntu
         'lucid',
@@ -58,4 +39,4 @@ def isDistroEOL(*, ros_distro_name=None, os_distro_name=None):
         'jessie',
         'stretch',
     ]
-    return os_distro_name in eol_base_images or ros_distro_name in eol_ros_distros
+    return os_distro_name in eol_base_images

--- a/docker_templates/packages.py
+++ b/docker_templates/packages.py
@@ -17,6 +17,8 @@ import string
 import re
 import urllib.request
 
+import rosdistro
+
 from docker_templates.eol_distro import isDistroEOL
 
 # TODO: think of a better version pattern like
@@ -124,12 +126,23 @@ def expandPackages(data):
     for package_type in indexUrlTemplateLookup:
         if package_type in data:
             # determine if distro is eol and apply the appropriate index URL template
-            ros_distro_name = ''
-            if package_type == 'ros_packages':
-                ros_distro_name = data['rosdistro_name']
-            elif package_type == 'ros2_packages':
-                ros_distro_name = data['ros2distro_name']
-            eol = isDistroEOL(ros_distro_name=ros_distro_name, os_distro_name=data['os_code_name'])
+            ros_distro_name = ""
+            if package_type == "ros_packages":
+                ros_distro_name = data["rosdistro_name"]
+            elif package_type == "ros2_packages":
+                ros_distro_name = data["ros2distro_name"]
+            if ros_distro_name != "":
+                index = rosdistro.get_index(rosdistro.get_index_url())
+                dist_info = index.distributions[ros_distro_name]
+                eol = isDistroEOL(
+                    ros_distro_status=dist_info["distribution_status"],
+                    os_distro_name=data["os_code_name"],
+                )
+            else:
+                eol = isDistroEOL(
+                    ros_distro_status=None,
+                    os_distro_name=data["os_code_name"],
+                )
             if eol:
                 package_index_url_template = indexUrlTemplateLookup[package_type + '_snapshots']
             else:

--- a/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_base_image.Dockerfile.em
@@ -25,7 +25,7 @@
 @
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version='1',
+    ros_distro=ros_distro,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -42,8 +42,7 @@ template_dependencies = [
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    rosdistro_name=rosdistro_name,
-    ros_version=ros_version,
+    ros_distro=rosdistro_name,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_image.Dockerfile.em
@@ -23,7 +23,7 @@
 @[if 'bootstrap_ros_tools' in locals()]@
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
+    ros_distro=rosdistro_name,
     os_code_name=os_code_name,
 ))@
 

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -46,9 +46,7 @@ if 'pip3_install' in locals():
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    ros2distro_name=ros2distro_name,
-    rosdistro_name='',
-    ros_version=ros_version,
+    ros_distro=ros2distro_name,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_image.Dockerfile.em
@@ -30,7 +30,7 @@ if 'pip3_install' in locals():
 @[if 'bootstrap_ros_tools' in locals()]@
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
+    ros_distro=ros2distro_name,
 ))@
 
 # bootstrap rosdep

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -39,8 +39,7 @@ RUN pip3 install -U \
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    rosdistro_name=rosdistro_name,
-    ros_version='1',
+    ros_distro=rosdistro_name,
 ))@
 
 ENV ROS1_DISTRO @rosdistro_name

--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -1,20 +1,25 @@
 @{
-if int(ros_version) == 2:
-    package_list = [
-        'build-essential',
+import rosdistro
+index = rosdistro.get_index(rosdistro.get_index_url())
+dist_info = index.distributions[ros_distro]
+ros_version = int(dist_info['distribution_type'][-1])
+ros_python_version = dist_info['python_version']
+prefix = 'python'
+if ros_python_version == 3:
+    prefix += str(ros_python_version)
+package_list = [
+    'build-essential',
+    f'{prefix}-rosdep',
+]
+if ros_version == 2:
+    package_list += [
         'git',
-        'python3-colcon-common-extensions',
-        'python3-colcon-mixin',
-        'python3-rosdep',
-        'python3-vcstool',
+        f'{prefix}-colcon-common-extensions',
+        f'{prefix}-colcon-mixin',
+        f'{prefix}-vcstool',
     ]
 else:
-    prefix = "python"
-    if 'os_code_name' in locals() and os_code_name in ['buster', 'focal']:
-        prefix += "3"
-    package_list = [
-        'build-essential',
-        f'{prefix}-rosdep',
+    package_list += [
         f'{prefix}-rosinstall',
         f'{prefix}-vcstools',
     ]

--- a/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
+++ b/docker_templates/templates/snippet/install_ros_bootstrap_tools.Dockerfile.em
@@ -2,6 +2,7 @@
 import rosdistro
 index = rosdistro.get_index(rosdistro.get_index_url())
 dist_info = index.distributions[ros_distro]
+# distribution_type is 'ros1' or 'ros2' we retrieve the ROS version number (1 or 2) as an int: https://www.ros.org/reps/rep-0153.html#index-file
 ros_version = int(dist_info['distribution_type'][-1])
 ros_python_version = dist_info['python_version']
 prefix = 'python'

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r') as f:
 install_requires = [
     'empy',
     'pyyaml',
+    'rosdistro',
     'ros_buildfarm',
 ]
 


### PR DESCRIPTION
Part of https://github.com/osrf/docker_images/issues/406

Here we can leverage the ROS distribution name to retrieve things like ROS version, Python major version and eol status.
This will allow us to remove some hardcoding we had to do left and right to handle sublte changes between ROS 1, ROS2 and ROS1 versions using python3.

The main gain is that we will not have to come update the hardcoded list of ROS EOL distros anymore.

However this implies downloading and parsing the [rosdistro global index file](https://github.com/ros/rosdistro/blob/4ffd760fc7b230106affaa469dc6e9b1e9672297/index-v4.yaml) in a couple places. Doesnt seem like a big deal to me as the file is tiny and multiple parts of the generation pipeline require fetching info from outside sources