### PR TITLE
add buster to list of EOL distros

### DIFF
--- a/docker_templates/eol_distro.py
+++ b/docker_templates/eol_distro.py
@@ -38,5 +38,6 @@ def isDistroEOL(*, ros_distro_status=None, os_distro_name=None):
         'wheezy',
         'jessie',
         'stretch',
+        'buster',
     ]
     return os_distro_name in eol_base_images


### PR DESCRIPTION
ROS buildfarm will stop building Buster packages shortly https://github.com/ros-infrastructure/ros_buildfarm_config/pull/221

We should switch to the snapshots repos a build a last image on dockerhub before retiring.

@sloretz (@nuclearsandwich ?) do you know when the debs of the last sync with debian Buster packages will be pushed to the snapshots apt repository under the final tag ?

Related to https://github.com/osrf/docker_images/issues/660