### PR TITLE
Use os-named folder for snapshots repos package retrieval

### DIFF
--- a/docker_templates/packages.py
+++ b/docker_templates/packages.py
@@ -37,8 +37,8 @@ indexUrlTemplateLookup = {
     'gazebo_packages':  string.Template('http://packages.osrfoundation.org/gazebo/$os_name-$release/dists/$os_code_name/main/binary-$arch/Packages.gz'),
     'ros_packages':     string.Template('http://packages.ros.org/ros/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
     'ros2_packages':    string.Template('http://packages.ros.org/ros2/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
-    'ros_packages_snapshots':    string.Template('http://snapshots.ros.org/$rosdistro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
-    'ros2_packages_snapshots':    string.Template('http://snapshots.ros.org/$ros2distro_name/final/ubuntu/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros_packages_snapshots':    string.Template('http://snapshots.ros.org/$rosdistro_name/final/$os_name/dists/$os_code_name/main/binary-$arch/Packages.gz'),
+    'ros2_packages_snapshots':    string.Template('http://snapshots.ros.org/$ros2distro_name/final/$os_name/dists/$os_code_name/main/binary-$arch/Packages.gz'),
 }
 
 packageVersionTemplateLookup = {


### PR DESCRIPTION
snapshots.ros.org now provide os-named folders (e.g. http://snapshots.ros.org/melodic/final/debian/dists/).
As opposed to packages.ros.org that places everything in the "ubuntu" folder
In the future they will likely not mirror the debian packages in the ubuntu folder: e.g. upcoming buster final snapshot: http://snapshots.ros.org/noetic/final/ so this PR makes us point to the right place.

Although looking at previous snapshots of ROS Noetic I dont see the debian folder but also cant find buster in the ubuntu folder distro list so maybe I'm missing something here.

@nuclearsandwich Does this PR seems appropriate to you ?

---

PR tested successfully on melodic / stretch
