### PR TITLE
setup key before source list to force rebuild

### DIFF
--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -27,8 +27,8 @@ else:
             source_suffix = 'testing'
     repo_url = f'http://packages.ros.org/ros{apt_suffix}/ubuntu'
 }@
-# setup sources.list
-RUN echo "deb @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list
-
 # setup keys
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys @(repo_key)
+
+# setup sources.list
+RUN echo "deb @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list


### PR DESCRIPTION
This will allow to rebuild images and make them pull the new gpg key as the old one expired

One of the approaches to deal with https://github.com/osrf/docker_images/issues/697