### PR TITLE
use gpg keyrings instead of apt-key

### DIFF
--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -22,7 +22,6 @@
 template_dependencies = [
     'dirmngr',
     'gnupg2',
-    'lsb-release',
 ]
 }@
 @(TEMPLATE(

--- a/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_gzserver_image.Dockerfile.em
@@ -31,12 +31,20 @@ template_dependencies = [
     upstream_packages=upstream_packages if 'upstream_packages' in locals() else [],
 ))@
 
+
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D2486D2DD83DB69272AFE98867170598AF249743
+RUN set -eux; \
+	key='D2486D2DD83DB69272AFE98867170598AF249743'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	mkdir -p /etc/apt/keyrings; \
+	gpg --batch --export "$key" > /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"
 
 # setup sources.list
 RUN . /etc/os-release \
-    && echo "deb http://packages.osrfoundation.org/gazebo/$ID-stable `lsb_release -sc` main" > /etc/apt/sources.list.d/gazebo-latest.list
+    && echo "deb [ signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg ] http://packages.osrfoundation.org/gazebo/$ID-stable $VERSION_CODENAME main" > /etc/apt/sources.list.d/gazebo-latest.list
 
 @(TEMPLATE(
     'snippet/label_and_install_package_list.Dockerfile.em',

--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -28,7 +28,14 @@ else:
     repo_url = f'http://packages.ros.org/ros{apt_suffix}/ubuntu'
 }@
 # setup keys
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys @(repo_key)
+RUN set -eux; \
+       key='@(repo_key)'; \
+       export GNUPGHOME="$(mktemp -d)"; \
+       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+       mkdir -p /etc/apt/keyrings; \
+       gpg --batch --export "$key" > /usr/share/keyrings/ros@(ros_version)-@(source_suffix)-archive-keyring.gpg; \
+       gpgconf --kill all; \
+       rm -rf "$GNUPGHOME"
 
 # setup sources.list
-RUN echo "deb @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list
+RUN echo "deb [ signed-by=/usr/share/keyrings/ros@(ros_version)-@(source_suffix)-archive-keyring.gpg ] @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list


### PR DESCRIPTION
First step to adress https://github.com/osrf/docker_images/issues/621
This update the template for the gzserver image as well as the common snippet used for all ROS images to use gpg directly instead of apt-key

Needed by https://github.com/osrf/docker_images/pull/705
Following recommendations from https://github.com/docker-library/official-images/pull/15809#issuecomment-1846053036

