### PR TITLE
[WIP] test installing the ros(2)-apt-source packages

### DIFF
--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -28,6 +28,7 @@
 @
 @{
 template_dependencies = [
+    'curl',
     'dirmngr',
     'gnupg2',
 ]

--- a/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images/create_ros_core_image.Dockerfile.em
@@ -29,6 +29,7 @@
 @{
 template_dependencies = [
     'curl',
+    'ca-certificates',
     'dirmngr',
     'gnupg2',
 ]

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -28,6 +28,7 @@
 @
 @{
 template_dependencies = [
+    'curl',
     'dirmngr',
     'gnupg2',
 ]

--- a/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/create_ros_core_image.Dockerfile.em
@@ -29,6 +29,7 @@
 @{
 template_dependencies = [
     'curl',
+    'ca-certificates',
     'dirmngr',
     'gnupg2',
 ]

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -16,6 +16,7 @@
 @{
 template_dependencies = [
     'curl',
+    'ca-certificates',
 ]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
 if 'pip3_install' in locals():

--- a/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/ros1_bridge/create_ros_ros1_bridge_image.Dockerfile.em
@@ -14,7 +14,9 @@
     maintainer_name=maintainer_name,
 ))@
 @{
-template_dependencies = []
+template_dependencies = [
+    'curl',
+]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
 if 'pip3_install' in locals():
     if isinstance(pip3_install, list) and pip3_install != []:

--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -30,7 +30,8 @@ else:
 
 # NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
 # NOTE: How do we break cache and ensure rebuild if that version changes ?
-RUN . /etc/os-release && ROS_APT_SOURCE_VERSION=`curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}'` curl -L -s -o /tmp/ros@(apt_suffix)-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros@(apt_suffix)-apt-source_${ROS_APT_SOURCE_VERSION}.$VERSION_CODENAME_all.deb" \
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') ;\
+    curl -L -s -o /tmp/ros@(apt_suffix)-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros@(apt_suffix)-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
     && apt-get update \
     && apt-get install /tmp/ros@(apt_suffix)-apt-source.deb \
     && rm -f /tmp/ros@(apt_suffix)-apt-source.deb

--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -27,15 +27,10 @@ else:
             source_suffix = 'testing'
     repo_url = f'http://packages.ros.org/ros{apt_suffix}/ubuntu'
 }@
-# setup keys
-RUN set -eux; \
-       key='@(repo_key)'; \
-       export GNUPGHOME="$(mktemp -d)"; \
-       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /usr/share/keyrings; \
-       gpg --batch --export "$key" > /usr/share/keyrings/ros@(ros_version)-@(source_suffix)-archive-keyring.gpg; \
-       gpgconf --kill all; \
-       rm -rf "$GNUPGHOME"
 
-# setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros@(ros_version)-@(source_suffix)-archive-keyring.gpg ] @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list
+# NOTE: this doesnt deal with snapshots repo as not clear what to install for those..
+# NOTE: How do we break cache and ensure rebuild if that version changes ?
+RUN . /etc/os-release && ROS_APT_SOURCE_VERSION=`curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}'` curl -L -s -o /tmp/ros@(apt_suffix)-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros@(apt_suffix)-apt-source_${ROS_APT_SOURCE_VERSION}.$VERSION_CODENAME_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros@(apt_suffix)-apt-source.deb \
+    && rm -f /tmp/ros@(apt_suffix)-apt-source.deb


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_templates/pull/109
ROS is now providing key packages: https://discourse.ros.org/t/ros-signing-key-expiracy/43826

But the keys expire on June 1st so this is becoming very urgent.

This PR is still not working, some things to figure out:
- why is the deb download not working in docker build
- why is the package installation failing wit following error message:
```
E: Invalid archive signature
E: Internal error, could not locate member control.tar.{zstlz4gzxzbz2lzma}
E: Could not read meta data from /tmp/ros1-apt-source.deb
E: The package lists or status file could not be parsed or opened.
```
- how to make a less ugly way to retrieve et propagate the deb version as it's unreadable in the current state
- What to do with snapshots repository ? I cant seem to find a package holding keyx for those

@tfoote @nuclearsandwich @ruffsl fyi
