### PR TITLE
[apt key] Follow up of #114: fix snapshots, test testing repo, breack cache on ros-apt-source version change

### DIFF
--- a/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/devel/create_ros_image.Dockerfile.em
@@ -13,9 +13,10 @@ FROM $FROM_IMAGE
 ))@
 @{
 template_dependencies = [
+    'ca-certificates',
+    'curl',
     'dirmngr',
     'gnupg2',
-    'lsb-release',
 ]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
 if 'pip3_install' in locals():
@@ -32,9 +33,7 @@ if 'pip3_install' in locals():
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    ros2distro_name='rolling',
-    rosdistro_name='',
-    ros_version=ros_version,
+    ros_distro='rolling',
 ))@
 
 # setup environment
@@ -43,7 +42,7 @@ ENV LC_ALL=C.UTF-8
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
+    ros_distro='rolling',
 ))@
 
 @[if 'ros2_repo_packages' in locals()]@

--- a/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/nightly/create_ros_image.Dockerfile.em
@@ -20,11 +20,12 @@
 ))@
 @{
 template_dependencies = [
+    'ca-certificates',
     'cmake',
+    'curl',
     'dirmngr',
     'git',
     'gnupg2',
-    'lsb-release',
     'wget',
 ]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
@@ -42,14 +43,12 @@ if 'pip3_install' in locals():
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    ros2distro_name=ros2distro_name,
-    rosdistro_name='',
-    ros_version=ros_version,
+    ros_distro=ros2distro_name,
 ))@
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
+    ros_distro=ros2distro_name,
 ))@
 
 # setup environment

--- a/docker_templates/templates/docker_images_ros2/testing/create_ros_image.Dockerfile.em
+++ b/docker_templates/templates/docker_images_ros2/testing/create_ros_image.Dockerfile.em
@@ -13,9 +13,10 @@ FROM $FROM_IMAGE
 ))@
 @{
 template_dependencies = [
+    'ca-certificates',
+    'curl',
     'dirmngr',
     'gnupg2',
-    'lsb-release',
 ]
 # add 'python3-pip' to 'template_dependencies' if pip dependencies are declared
 if 'pip3_install' in locals():
@@ -32,15 +33,13 @@ if 'pip3_install' in locals():
     'snippet/setup_ros_sources.Dockerfile.em',
     os_name=os_name,
     os_code_name=os_code_name,
-    ros2distro_name='rolling',
-    rosdistro_name='',
-    ros_version=ros_version,
+    ros_distro='rolling',
     testing_repo=True,
 ))@
 
 @(TEMPLATE(
     'snippet/install_ros_bootstrap_tools.Dockerfile.em',
-    ros_version=ros_version,
+    ros_distro='rolling',
 ))@
 
 # setup environment


### PR DESCRIPTION
Follow-up of https://github.com/osrf/docker_templates/pulls/114

Addresses: https://github.com/osrf/docker_templates/issues/115


What it does:
- Add back old logic for EOL images so snapshots based images are still able to install packages
- For non EOL: evaluate ros{2}-apt-source version at Dockerfile generation time so a version change will burst docker cache
- Fix broken ros2 source/testing template to test the ros2-testing apt repo configuration:

<details><summary>Tested the following diff and it's working successfully</summary>

```diff
 # setup timezone
 RUN echo 'Etc/UTC' > /etc/timezone && \
@@ -9,27 +12,17 @@ RUN echo 'Etc/UTC' > /etc/timezone && \
 
 # install packages
 RUN apt-get update && apt-get install -q -y --no-install-recommends \
+    ca-certificates \
+    curl \
     dirmngr \
     gnupg2 \
     && rm -rf /var/lib/apt/lists/*
 
-# setup keys
-RUN set -eux; \
-       key='C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'; \
-       export GNUPGHOME="$(mktemp -d)"; \
-       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
-       mkdir -p /usr/share/keyrings; \
-       gpg --batch --export "$key" > /usr/share/keyrings/ros2-testing-archive-keyring.gpg; \
-       gpgconf --kill all; \
-       rm -rf "$GNUPGHOME"
 
-# setup sources.list
-RUN echo "deb [ signed-by=/usr/share/keyrings/ros2-testing-archive-keyring.gpg ] http://packages.ros.org/ros2-testing/ubuntu noble main" > /etc/apt/sources.list.d/ros2-testing.list
-
-# setup environment
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-ENV ROS_DISTRO rolling
+RUN curl -L -s -o /tmp/ros2-testing-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-testing-apt-source_1.1.0.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+    && apt-get update \
+    && apt-get install /tmp/ros2-testing-apt-source.deb \
+    && rm -f /tmp/ros2-testing-apt-source.deb
```

</details>