### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/docker_templates/create.py
+++ b/docker_templates/create.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
-import pkg_resources
 import shutil
 
 import ros_buildfarm.templates
@@ -29,8 +29,8 @@ def expand_template_prefix_path(template_packages):
 
     # expand template_prefix_path in order of preference
     for template_package in reversed(template_packages):
-        template_package_path = pkg_resources.resource_filename(
-            template_package, 'templates')
+        template_package_path = importlib.resources.files(
+            template_package) / 'templates'
         ros_buildfarm.templates.template_prefix_path.insert(
             0, template_package_path)
 


### PR DESCRIPTION
pkg_resources has been deprecated for a while.
Since Feb 9th 2026 the nightly jobs of osrf/docker_images fail because of inability to import pkg_resources: https://github.com/osrf/docker_images/actions/runs/21808581716

This PR replaces it following logic from: https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename.

With this PR docker_images CI passes again: https://github.com/osrf/docker_images/actions/runs/22475526380/