### PR TITLE
fix importlib.resources Attribute error on Python 3.14

### DIFF
--- a/docker_templates/create.py
+++ b/docker_templates/create.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+from importlib import resources
 import os
 import shutil
 


### PR DESCRIPTION
On recent python the createpy script crashes with the following error:

```
Traceback (most recent call last):
  File "/tmp/docker_images/ros/./create_dockerlibrary.py", line 50, in <module>
    main()
    ~~~~^^
  File "/tmp/docker_images/ros/./create_dockerlibrary.py", line 45, in main
    expand_template_prefix_path(template_packages)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/docker_templates/create.py", line 32, in expand_template_prefix_path
    template_package_path = importlib.resources.files(
                            ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'resources'
```

Adding an explicit import of the resources module seems to fix the issue.

I confirmed on ubuntu:resolute that the same error occurs in a Python shell:

```
Python 3.14.4 (main, Apr  8 2026, 04:02:31) [GCC 15.2.0] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> importlib.resources.files
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    importlib.resources.files
    ^^^^^^^^^
NameError: name 'importlib' is not defined. Did you forget to import 'importlib'?
>>> import importlib
>>> importlib.resources.files
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    importlib.resources.files
    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'resources'
>>> from importlib import resources
>>> importlib.resources.files
<function files at 0x75f91d5a21f0>
```