### PR TITLE
pass fail flag to fail early and use binary mode for sha check

### DIFF
--- a/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
+++ b/docker_templates/templates/snippet/setup_ros_sources.Dockerfile.em
@@ -63,8 +63,8 @@ RUN set -eux; \
 RUN echo "deb [ signed-by=/usr/share/keyrings/ros@(ros_version)-@(source_suffix)-archive-keyring.gpg ] @(repo_url) @(os_code_name) main" > /etc/apt/sources.list.d/ros@(ros_version)-@(source_suffix).list
 @[else]@
 # Setup ROS Apt sources
-RUN curl -L -s -o @(temp_filename) @(fetch_url) \
-    && echo "@(file_256checksum) @(temp_filename)" | sha256sum --strict --check \
+RUN curl -L -s -f -o @(temp_filename) @(fetch_url) \
+    && echo "@(file_256checksum) *@(temp_filename)" | sha256sum --strict --check \
     && apt-get update \
     && apt-get install @(temp_filename) \
     && rm -f @(temp_filename) \


### PR DESCRIPTION
Used for https://github.com/osrf/docker_images/pull/880